### PR TITLE
feat(Toas as APIs): ORB-1941 - Alterar textos de Open Banking Brasil

### DIFF
--- a/swagger-apis/acquiring-services/1.0.0-rc1.0.yml
+++ b/swagger-apis/acquiring-services/1.0.0-rc1.0.yml
@@ -1,15 +1,15 @@
 ﻿openapi: 3.0.0
 info:
-  title: API Acquiring Services - Open Banking Brasil
+  title: API Acquiring Services - Open Finance Brasil
   description: |
-    API de Credenciamento do Open Banking Brasil – Fase 4.
+    API de Credenciamento do Open Finance Brasil – Fase 4.
     API que retorna informações de Credenciamento.
   version: 1.0.0-rc1.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
   contact:
-    name: Governança do Open Banking Brasil – Especificações
+    name: Governança do Open Finance Brasil – Especificações
     email: gt-interfaces@openbankingbr.org
     url: 'https://openbanking-brasil.github.io/areadesenvolvedor/'
 servers:

--- a/swagger-apis/admin/1.0.2.yml
+++ b/swagger-apis/admin/1.0.2.yml
@@ -1,6 +1,6 @@
 ﻿openapi: 3.0.0
 info:
-  title: APIs Admin do Open Banking Brasil
+  title: APIs Admin do Open Finance Brasil
   description: As API's administrativas são recursos que podem ser consumidos apenas pelo diretório para avaliação e controle da qualidade dos serviços fornecidos pelas instituições financeiras
   version: 1.0.2
   contact:

--- a/swagger-apis/channels/1.0.2.yml
+++ b/swagger-apis/channels/1.0.2.yml
@@ -1,7 +1,7 @@
 ﻿openapi: 3.0.0
 info:
-  title: APIs OpenData do Open Banking Brasil
-  description: As APIs descritas neste documento são referentes as APIs da fase OpenData do Open Banking Brasil.
+  title: APIs OpenData do Open Finance Brasil
+  description: As APIs descritas neste documento são referentes as APIs da fase OpenData do Open Finance Brasil.
   version: 1.0.2
   contact:
     url: 'https://servicedesk.openbankingbrasil.org.br/Login.jsp?navLanguage=pt-BR'

--- a/swagger-apis/investments/1.0.0-rc1.0.yml
+++ b/swagger-apis/investments/1.0.0-rc1.0.yml
@@ -1,15 +1,15 @@
 ﻿openapi: 3.0.0
 info:
-  title: API Investments - Open Banking Brasil
+  title: API Investments - Open Finance Brasil
   description: |
     Estas APIs visam o compartilhamento de dados sobre Investimentos e suas
-    características entre as Instituições Financeiras participantes do Open Banking Brasil
+    características entre as Instituições Financeiras participantes do Open Finance Brasil
   version: 1.0.0-rc1.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
   contact:
-    name: Governança do Open Banking Brasil – Especificações
+    name: Governança do Open Finance Brasil – Especificações
     email: gt-interfaces@openbankingbr.org
     url: 'https://openbanking-brasil.github.io/areadesenvolvedor/'
 servers:

--- a/swagger-apis/products-services/1.0.2.yml
+++ b/swagger-apis/products-services/1.0.2.yml
@@ -1,7 +1,7 @@
 ﻿openapi: 3.0.0
 info:
-  title: API's OpenData do Open Banking Brasil
-  description: As API's descritas neste documento são referentes as API's da fase OpenData do Open Banking Brasil.
+  title: API's OpenData do Open Finance Brasil
+  description: As API's descritas neste documento são referentes as API's da fase OpenData do Open Finance Brasil.
   version: 1.0.2
   contact:
     url: 'https://servicedesk.openbankingbrasil.org.br/Login.jsp?navLanguage=pt-BR'


### PR DESCRIPTION
Alterado texto de "Open Banking" para "Open Finance" nas APIs:
- Produtos e serviços
- Canais de atendimento
- Investimentos
- Credenciamento
- Admins