### PR TITLE
GT-C - Feat(Pension) - PC50, PC54, PC55, PC57, PC58, PC59, PC60, PC62

### DIFF
--- a/dictionary/getPensionRiskCoverages_v1.csv
+++ b/dictionary/getPensionRiskCoverages_v1.csv
@@ -4,13 +4,22 @@
 /data/participant/brand;brand;Nome da marca reportada pelo participante do Open Finance. O conceito a que se refere a 'marca' é em essência uma promessa da empresa em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Organização;
 /data/participant/name;name;Nome do participante do Open Finance.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Organização A1;
 /data/participant/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
-/data/participant/urlComplementaryList;urlComplementaryList;;Texto;1024;Opcional;^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$;;0;1;"";Não permitido;string;https://empresaa1.com/companies;
+/data/participant/urlComplementaryList;urlComplementaryList;"Espera-se que valor de retorno, após acesso ao link ‘urlComplementaryList’, deve ser array de objeto com a estrutura abaixo:
+
+- ‘name’ com o valor contido no campo ‘LegalEntityName’ conforme cadastro no diretório;
+
+- ‘cnpjNumber’ com o valor contido no campo CNPJ (‘RegistrationNumber’) correspondente a esta instituição;
+
+- Ambos do tipo string;
+
+- Ambos obrigatórios.
+";Texto;1024;Opcional;^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$;;0;1;"";Não permitido;string;https://empresaa1.com/companies;
 /data/society;society;Conjunto de informações relativas à seguradora do produto de open insurance;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/society/name;name;Nome da Sociedade Seguradora.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Society A1;
 /data/society/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
 /data/name;name;Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Produto A;
 /data/code;code;Código único a ser definido pela sociedade.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;0001;
-/data/modality;modality;<ol><li>Funeral</li><li>Prestamista (exceto Habitacional e Rural)</li><li>Viagem</li><li>Educacional</li><li>Dotal (Misto e Puro)</li><li>Acidentes Pessoais</li><li>Vida</li><li>Perda do Certificado de Habilitação de Voo – PCHV</li><li>Doenças Graves ou Doença Terminal</li><li>Desemprego/ Perda de Renda</li><li>Eventos Aleatórios</li><li>Pecúlio</li><li>Pensão prazo certo</li><li>Pensão menores 21 anos</li><li>Pensão menores 24 anos</li><li>Pensão cônjuge vitalícia</li><li>Pensão cônjuge temporária</li></ol>;Texto;33;Opcional;;"FUNERAL 
+/data/modality;modality;<ol><li>Funeral</li><li>Prestamista (exceto Habitacional e Rural)</li><li>Viagem</li><li>Educacional</li><li>Dotal (Misto e Puro)</li><li>Acidentes Pessoais</li><li>Vida</li><li>Perda do Certificado de Habilitação de Voo – PCHV</li><li>Doenças Graves ou Doença Terminal</li><li>Desemprego/ Perda de Renda</li><li>Eventos Aleatórios</li><li>Pecúlio</li><li>Pensão prazo certo</li><li>Pensão menores 21 anos</li><li>Pensão menores 24 anos</li><li>Pensão cônjuge vitalícia</li><li>Pensão cônjuge temporária</li></ol>;Texto;33;Obrigatório;;"FUNERAL 
 PRESTAMISTA 
 VIAGEM 
 EDUCACIONAL 
@@ -26,7 +35,7 @@ PENSAO_PRAZO_CERTO
 PENSAO_MENORES_21 
 PENSAO_MENORES_24 
 PENSAO_CONJUGE_VITALICIA 
-PENSAO_CONJUGE_TEMPORARIA";0;1;"";Não permitido;string;FUNERAL;
+PENSAO_CONJUGE_TEMPORARIA";1;1;"";Não permitido;string;FUNERAL;
 /data/coverages;coverages;;Lista;;Obrigatório;;;1;N;"";Não permitido;array;;
 /data/coverages/type;type;É o conjunto dos riscos cobertos elencados na apólice. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela Tipo de Cobertura.;Texto;9;Obrigatório;;"MORTE 
 INVALIDEZ 
@@ -34,16 +43,31 @@ OUTROS";1;1;"";Não permitido;string;MORTE;
 /data/coverages/typeAdditionalInfos;typeAdditionalInfos;"Lista de textos para complementar informação relativa ao campo type, quando for selecionada a opção 'OUTROS'.
 Restrição: Campo de preenchimento obrigatório se 'type' estiver preenchida a opção 'OUTROS'
 ";Lista;100;Opcional;;;0;N;"";Não permitido;array;;
-/data/coverages/attributes;attributes;Atributos da cobertura;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/coverages/attributes;attributes;Atributos da cobertura;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/coverages/attributes/minValue;minValue;Listagem do valor mínimo de cobertura (Capital Segurado), diária ou parcela aceito pela sociedade para cada combinação de modalidade/cobertura do produto.<br>Conforme moeda.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/coverages/attributes/minValue/amount;amount;;Texto;21;Obrigatório;^\d{1,16}\.\d{2,4}$;;1;1;"";Não permitido;string;0.01;
 /data/coverages/attributes/minValue/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL;
 /data/coverages/attributes/maxValue;maxValue;Listagem do valor máximo de cobertura (Capital Segurado), diária ou parcela aceito pela sociedade para cada combinação de modalidade/cobertura do produto.<br>Conforme moeda.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/coverages/attributes/maxValue/amount;amount;;Texto;21;Obrigatório;^\d{1,16}\.\d{2,4}$;;1;1;"";Não permitido;string;0.01;
 /data/coverages/attributes/maxValue/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL;
-/data/coverages/attributes/indemnifiablePeriods;indemnifiablePeriods;;Lista;31;Opcional;;"QUANTIDADE_DETERMINADA_PARCELAS 
-FIM_CICLO_DETERMINADO";0;N;"";Não permitido;array;QUANTIDADE_DETERMINADA_PARCELAS;
-/data/coverages/attributes/excludedRisks;excludedRisks;;Lista;40;Opcional;;"ATO_RECONHECIMENTO_PERIGOSO 
+/data/coverages/attributes/indemnifiablePeriod;indemnifiablePeriod;"Listagem do pagamento para cada benefício:
+  1. Quantidade determinada de parcelas;
+  2. Até o fim de ciclo determinado.
+Se for pagamento único, esse campo não se aplica (retorna vazio).
+";Texto;;Opcional;;"QUANTIDADE_DETERMINADA_PARCELAS 
+FIM_CICLO_DETERMINADO";0;1;"";Não permitido;string;QUANTIDADE_DETERMINADA_PARCELAS;
+/data/coverages/attributes/indemnifiableDeadline;indemnifiableDeadline;Número máximo de parcelas indenizáveis. Caso seja relacionado a parcelas.;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;;
+/data/coverages/attributes/indemnityPaymentMethod;indemnityPaymentMethod;"Modalidade de pagamento da indenização, a considerar os domínios abaixo:
+  1. Único
+  2. Sob a forma de renda
+";Texto;;Obrigatório;;"UNICO 
+SOB_FORMA_RENDA";1;1;"";Não permitido;string;UNICO;
+/data/coverages/attributes/gracePeriod;gracePeriod;Período de carência da cobertura;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/coverages/attributes/gracePeriod/amount;amount;Informar o prazo de carência;Inteiro;;Opcional;;;0;1;"";Não permitido;integer;90;
+/data/coverages/attributes/gracePeriod/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Opcional;;"DIAS 
+MESES 
+NAO_APLICA";0;1;"";Não permitido;string;MESES;
+/data/coverages/attributes/excludedRisks;excludedRisks;;Lista;40;Obrigatório;;"ATO_RECONHECIMENTO_PERIGOSO 
 ATO_ILICITO_DOLOSO_PRATICADO_SEGURADO 
 OPERACOES_GUERRA 
 FURACOES_CICLONES_TERREMOTOS 
@@ -52,9 +76,12 @@ DOENCAS_LESOES_PREEXISTENTES
 EPIDEMIAS_PANDEMIAS 
 SUICIDIO 
 ATO_ILICITO_DOLOSO_PRATICADO_CONTROLADOR 
-OUTROS";0;N;"";Não permitido;array;ATO_RECONHECIMENTO_PERIGOSO;
-/data/coverages/attributes/excludedRisksURL;excludedRisksURL;Campo aberto (possibilidade de incluir URL).;Texto;1024;Opcional;;;0;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
-/data/assistanceTypes;assistanceTypes;;Lista;43;Obrigatório;;"ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA 
+OUTROS";1;N;"";Não permitido;array;ATO_RECONHECIMENTO_PERIGOSO;
+/data/coverages/attributes/excludedRisksURL;excludedRisksURL;Campo aberto (possibilidade de incluir URL).;Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
+/data/coverages/attributes/profitModality;profitModality;"Modalidade de pagamento da indenização.
+";Texto;;Obrigatório;;"PAGAMENTO_UNICO 
+FORMA_RENDA";1;1;"";Não permitido;string;PAGAMENTO_UNICO;
+/data/assistanceTypes;assistanceTypes;;Lista;43;Opcional;;"ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA 
 ARQUITETO_VIRTUAL 
 ASSESSORIA_FINANCEIRA 
 AUTOMOVEL 
@@ -109,54 +136,113 @@ SUSTENTAVEL_DESCARTE_ECOLOGICO
 TELEMEDICINA 
 VIAGEM 
 VITIMA 
-OUTROS";1;N;"";Não permitido;array;ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA;
+OUTROS";0;N;"";Não permitido;array;ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA;
 /data/assistanceTypesAdditionalInfos;assistanceTypesAdditionalInfos;Lista a ser preenchida pelas participantes quando houver 'Outros' no campo 'Tipo de Assistência'.;Lista;;Opcional;;;0;N;"";Não permitido;array;;
-/data/additionals;additionals;;Lista;44;Obrigatório;;"SORTEIO 
+/data/additional;additional;;Texto;;Opcional;;"SORTEIO 
 SERVICOS_ASSISTENCIAS_COMPLEMENTARES_PAGO 
 SERVICOS_ASSISTENCIA_COMPLEMENTARES_GRATUITO 
 OUTROS 
-NAO_HA";1;N;"";Não permitido;array;SORTEIO;
+NAO_HA";0;1;"";Não permitido;string;SORTEIO;
 /data/termsAndConditions;termsAndConditions;;Lista;;Obrigatório;;;1;N;"";Não permitido;array;;
-/data/termsAndConditions/susepProcessNumber;susepProcessNumber;"Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.";Texto;20;Obrigatório;^\d{5}\.\d{6}/\d{4}-\d{2}$;;1;1;"";Não permitido;string;15414.622222/2222-22;
+/data/termsAndConditions/susepProcessNumber;susepProcessNumber;"Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.";Texto;20;Obrigatório;^\d{5}\.\d{6}\/\d{4}-\d{2}$|^\d{2}\.\d{6}\/\d{2}-\d{2}$|^\d{3}-\d{5}\/\d{2}$|^\d{5}\.\d{6}\/\d{2}-\d{2}$;;1;1;"";Não permitido;string;15414.622222/2222-22;12
 /data/termsAndConditions/detail;detail;Representam as Condições Gerais, Condições Especiais e Condições ou Cláusulas Particulares de um mesmo produto. (Circular SUSEP 321/06). Campo aberto (possibilidade de incluir URL);Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/pmbacRemuneration;pmbacRemuneration;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
-/data/pmbacRemuneration/interestRate;interestRate;Taxa de juros para capitalização da PMBaC;Texto;;Opcional;^\d{1,16}\.\d{4}$;;0;1;"";Não permitido;string;14.2521;
+/data/pmbacRemuneration/interestRate;interestRate;Taxa de juros para capitalização da PMBaC;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/pmbacRemuneration/updateIndexes;updateIndexes;;Lista;;Opcional;;"IPCA 
 IGP_M 
 INPC";0;N;"";Não permitido;array;IPCA;
+/data/premiumUpdateIndex;premiumUpdateIndex;Índice utilizado na atualização do prêmio/contribuição e do capital segurado/benefício;Texto;;Obrigatório;;"IPCA 
+IGPM 
+INPC";1;1;"";Não permitido;string;IPCA;
 /data/ageAdjustment;ageAdjustment;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/ageAdjustment/criterias;criterias;;Lista;27;Obrigatório;;"APOS_PERIODO_ANOS 
 CADA_PERIODO_ANOS 
 MUDANCA_FAIXA_ETARIA 
 NAO_APLICAVEL";1;N;"";Não permitido;array;APOS_PERIODO_ANOS;
 /data/ageAdjustment/frequency;frequency;Período em anos, caso critério de reenquadramento após ou a cada período em anos.;Inteiro;3;Obrigatório;;;1;1;"";Não permitido;integer;10;
-/data/financialRegimeContractTypes;financialRegimeContractTypes;;Lista;19;Opcional;;"REPARTICAO_SIMPLES 
+/data/financialRegimeContractType;financialRegimeContractType;"Listagem de regime financeiro para cada combinação de modalidade/cobertura do produto indicando:
+  1. Repartição simples
+  2. Repartição Capitais Cobertura
+  3. Capitalização
+";Texto;;Opcional;;"REPARTICAO_SIMPLES 
 REPARTICAO_CAPITAIS 
-CAPITALIZACAO";0;N;"";Não permitido;array;REPARTICAO_SIMPLES;
+CAPITALIZACAO";0;1;"";Não permitido;string;REPARTICAO_SIMPLES;
 /data/reclaim;reclaim;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/reclaim/table;table;;Lista;;Opcional;;;1;N;"";Não permitido;array;;
-/data/reclaim/table/initialMonthRange;initialMonthRange;;Inteiro;2;Opcional;;;0;1;"";Não permitido;integer;1;
-/data/reclaim/table/finalMonthRange;finalMonthRange;;Inteiro;2;Opcional;;;0;1;"";Não permitido;integer;12;
-/data/reclaim/table/percentage;percentage;Percentual de faixa de resgate.;Texto;6;Opcional;^\d\.\d{4}$;;0;1;"";Não permitido;string;0.5000;
-/data/reclaim/gracePeriod;gracePeriod;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
+/data/reclaim/table/initialMonthRange;initialMonthRange;;Inteiro;2;Obrigatório;;;1;1;"";Não permitido;integer;1;
+/data/reclaim/table/finalMonthRange;finalMonthRange;;Inteiro;2;Obrigatório;;;1;1;"";Não permitido;integer;12;
+/data/reclaim/table/percentage;percentage;Percentual de faixa de resgate.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
+/data/reclaim/gracePeriod;gracePeriod;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/reclaim/gracePeriod/amount;amount;Informar o prazo de carência;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;90;
-/data/reclaim/gracePeriod/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Obrigatório;;"DIAS 
+/data/reclaim/gracePeriod/unit;unit;"Informar o critério de carência para resgate:
+1. Dias;
+2. Meses;
+3. Não se aplica.
+";Texto;;Obrigatório;;"DIAS 
 MESES 
 NAO_APLICA";1;1;"";Não permitido;string;MESES;
 /data/reclaim/differenciatedPercentage;differenciatedPercentage;Campo aberto (possibilidade de incluir URL);"";1024;Opcional;;;0;1;"";Não permitido;;"https://openinsurance.com.br/aaa’
 Obs.: Exceção de cobertura ou critério definido acima será descrito aqui na URL
 Exemplo: Cobertura X: a partir de 25 meses = 100%
 ";
-/data/otherGuaranteedValues;otherGuaranteedValues;;Lista;20;Opcional;;"SALDAMENTO 
+/data/otherGuaranteedValues;otherGuaranteedValues;"1. Saldamento
+2. Benefício Prolongado
+3. Não se aplica
+";Texto;;Obrigatório;;"SALDAMENTO 
 BENEFICIO_PROLONGADO 
-NAO_APLICA";0;N;"";Não permitido;array;SALDAMENTO;
-/data/indemnityPaymentMethods;indemnityPaymentMethods;;Lista;18;Opcional;;"UNICO 
-SOB_FORMA_RENDA";0;N;"";Não permitido;array;UNICO;
-/data/minimumRequirement;minimumRequirement;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
-/data/minimumRequirement/contractType;contractType;"O tipo de serviço contratado. A considerar os domínios abaixo&#58;<br><ol><li>Coletivo Averbado</li><li>Coletivo Instituído</li><li>Individual</li></ol>";Texto;;Obrigatório;;"COLETIVO_AVERBADO 
-COLETIVO_INSTITUIDO 
-INDIVIDUAL";1;1;"";Não permitido;string;COLETIVO_AVERBADO;
-/data/minimumRequirement/contractingMinRequirement;contractingMinRequirement;Campo aberto contendo todos os requisitos mínimos para contratação (possibilidade de incluir URL).;Texto;1024;Opcional;;;0;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
+NAO_APLICA";1;1;"";Não permitido;string;SALDAMENTO;
+/data/contributionPayment;contributionPayment;Pagamento da contribuição.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/contributionPayment/contributionPaymentMethod;contributionPaymentMethod;"Forma de pagamento da contribuição.
+ - CARTAO_CREDITO
+ - DEBITO_CONTA
+ - DEBITO_CONTA_POUPANCA
+ - BOLETO_BANCARIO
+ - PIX
+ - TED_DOC
+ - CONSIGNACAO_FOLHA_PAGAMENTO
+ - PONTOS_PROGRAMA_BENEFICIO
+ - OUTROS
+";Texto;;Obrigatório;;"CARTAO_CREDITO 
+DEBITO_CONTA 
+DEBITO_CONTA_POUPANCA 
+BOLETO_BANCARIO 
+PIX 
+TED_DOC 
+CONSIGNACAO_FOLHA_PAGAMENTO 
+PONTOS_PROGRAMA_BENEFICIO 
+OUTROS";1;1;"";Não permitido;string;CARTAO_CREDITO;
+/data/contributionPayment/contributionPaymentMethodAdditionalInfo;contributionPaymentMethodAdditionalInfo;"Campo livre para preenchimento das informações adicionais referente ao contributionPaymentMethod.
+
+[Restrição] Obrigatório quando 'contributionPaymentMethod' for igual 'OUTROS'. 
+";Texto;140;Condicional;[\w\W\s]*;;0;1;" Obrigatório quando 'contributionPaymentMethod' for igual 'OUTROS'. 
+";Não permitido;string;Informações adicionais;
+/data/contributionPayment/contributionPeriodicity;contributionPeriodicity;"Periodicidade de pagamento da contribuição.
+- MENSAL
+- UNICA
+- ANUAL
+- TRIMESTRAL
+- SEMESTRAL
+- BIMESTRAL
+- OUTROS
+";Texto;;Obrigatório;;"MENSAL 
+UNICA 
+ANUAL 
+TRIMESTRAL 
+SEMESTRAL 
+BIMESTRAL 
+OUTROS";1;1;"";Não permitido;string;MENSAL;
+/data/contributionPayment/contributionPeriodicityAdditionalInfo;contributionPeriodicityAdditionalInfo;"Campo livre para preenchimento das informações adicionais referente ao contributionPaymentMethod.
+
+[Restrição] Obrigatório quando 'contributionPeriodicity' for igual 'OUTROS'.
+";Texto;140;Condicional;[\w\W\s]*;;0;1;" Obrigatório quando 'contributionPeriodicity' for igual 'OUTROS'.
+";Não permitido;string;Informações adicionais;
+/data/minimumRequirement;minimumRequirement;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/minimumRequirement/contractType;contractType;"O tipo de serviço contratado. A considerar os domínios abaixo:
+1. Coletivo;
+2. Individual.
+";Texto;;Obrigatório;;"COLETIVO 
+INDIVIDUAL";1;1;"";Não permitido;string;COLETIVO;
+/data/minimumRequirement/contractingMinRequirement;contractingMinRequirement;Campo aberto contendo todos os requisitos mínimos para contratação (possibilidade de incluir URL).;Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/targetAudience;targetAudience;"A considerar os domínios abaixo:
 
   1. Pessoa Natural

--- a/dictionary/getPensionSurvivalCoverages_v1.csv
+++ b/dictionary/getPensionSurvivalCoverages_v1.csv
@@ -4,7 +4,16 @@
 /data/participant/brand;brand;Nome da marca reportada pelo participante do Open Finance. O conceito a que se refere a 'marca' é em essência uma promessa da empresa em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Organização;
 /data/participant/name;name;Nome do participante do Open Finance.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Organização A1;
 /data/participant/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
-/data/participant/urlComplementaryList;urlComplementaryList;;Texto;1024;Opcional;^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$;;0;1;"";Não permitido;string;https://empresaa1.com/companies;
+/data/participant/urlComplementaryList;urlComplementaryList;"Espera-se que valor de retorno, após acesso ao link ‘urlComplementaryList’, deve ser array de objeto com a estrutura abaixo:
+
+- ‘name’ com o valor contido no campo ‘LegalEntityName’ conforme cadastro no diretório;
+
+- ‘cnpjNumber’ com o valor contido no campo CNPJ (‘RegistrationNumber’) correspondente a esta instituição;
+
+- Ambos do tipo string;
+
+- Ambos obrigatórios.
+";Texto;1024;Opcional;^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$;;0;1;"";Não permitido;string;https://empresaa1.com/companies;
 /data/society;society;Conjunto de informações relativas à seguradora do produto de open insurance;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/society/name;name;Nome da Sociedade Seguradora.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Society A1;
 /data/society/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
@@ -19,11 +28,11 @@
 PREVIDENCIA";1;1;"";Não permitido;string;PREVIDENCIA;
 /data/modality;modality;"1. Contribuição Variável;
 2. Benefício Definido.
-";Texto;21;Opcional;;"CONTRIBUICAO_VARIAVEL 
-BENEFICIO_DEFINIDO";0;1;"";Não permitido;string;BENEFICIO_DEFINIDO;
+";Texto;21;Obrigatório;;"CONTRIBUICAO_VARIAVEL 
+BENEFICIO_DEFINIDO";1;1;"";Não permitido;string;BENEFICIO_DEFINIDO;
 /data/additionalInfo;additionalInfo;Campo aberto (possibilidade de incluir URL);Texto;1024;Opcional;;;0;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/termsAndConditions;termsAndConditions;;Lista;;Opcional;;;1;N;"";Não permitido;array;;
-/data/termsAndConditions/susepProcessNumber;susepProcessNumber;"Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.";Texto;20;Obrigatório;^\d{5}\.\d{6}/\d{4}-\d{2}$;;1;1;"";Não permitido;string;15414.622222/2222-22;
+/data/termsAndConditions/susepProcessNumber;susepProcessNumber;"Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.";Texto;20;Obrigatório;^\d{5}\.\d{6}\/\d{4}-\d{2}$|^\d{2}\.\d{6}\/\d{2}-\d{2}$|^\d{3}-\d{5}\/\d{2}$|^\d{5}\.\d{6}\/\d{2}-\d{2}$;;1;1;"";Não permitido;string;15414.622222/2222-22;12
 /data/termsAndConditions/detail;detail;Representam as Condições Gerais, Condições Especiais e Condições ou Cláusulas Particulares de um mesmo produto. (Circular SUSEP 321/06). Campo aberto (possibilidade de incluir URL);Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/type;type;"1.  PGBL
 2.  PRGP
@@ -38,7 +47,7 @@ BENEFICIO_DEFINIDO";0;1;"";Não permitido;string;BENEFICIO_DEFINIDO;
 11. VRI
 12. VDR
 13. Demais produtos de Previdência.
-";Texto;27;Obrigatório;;"PGBL 
+";Texto;27;Opcional;;"PGBL 
 PRGP 
 PAGP 
 PRSA 
@@ -50,18 +59,19 @@ VAGP
 VRSA 
 VRI 
 VDR 
-DEMAIS_PRODUTOS_PREVIDENCIA";1;1;"";Não permitido;string;;
-/data/defferalPeriod;defferalPeriod;Período de Diferimento;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
-/data/defferalPeriod/interestRate;interestRate;Taxa de juros mensal garantida que remunera o plano durante a fase de diferimento/acumulação.;Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.251231;
+DEMAIS_PRODUTOS_PREVIDENCIA";0;1;"";Não permitido;string;;
+/data/defferalPeriod;defferalPeriod;Período de Diferimento;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/defferalPeriod/interestRate;interestRate;Taxa de juros mensal garantida que remunera o plano durante a fase de diferimento/acumulação.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/defferalPeriod/updateIndex;updateIndex;"Índice utilizado na atualização do prêmio e do capital segurado, caso critério de atualização por meio de índice:
 1. IPCA (IBGE);
 2. IGP-M (FGV);
 3. INPC (IBGE).
-";Texto;5;Opcional;;"IPCA 
+";Texto;5;Obrigatório;;"IPCA 
 IGP_M 
-INPC";0;1;"";Não permitido;string;IPCA;
-/data/defferalPeriod/otherMinimumPerformanceGarantees;otherMinimumPerformanceGarantees;Para produtos do tipo PDR e VDR, indicação do índice de ampla divulgação utilizados como garantia mínima de desempenho.;Texto;12;Opcional;;;0;1;"";Não permitido;string;SELIC;
-/data/defferalPeriod/reversalFinancialResults;reversalFinancialResults;Percentual de reversão de excedente financeiro na concessão. Em %.;Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.051230;
+INPC 
+NAO_SE_APLICA";1;1;"";Não permitido;string;IPCA;
+/data/defferalPeriod/otherMinimumPerformanceGarantees;otherMinimumPerformanceGarantees;Para produtos do tipo PDR e VDR, indicação do índice de ampla divulgação utilizados como garantia mínima de desempenho.;Texto;12;Obrigatório;;;1;1;"";Não permitido;string;SELIC;
+/data/defferalPeriod/reversalFinancialResults;reversalFinancialResults;Percentual de reversão de excedente financeiro na concessão. Em %.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/defferalPeriod/minimumPremiums;minimumPremiums;;Lista;;Opcional;;;0;N;"";Não permitido;array;;
 /data/defferalPeriod/minimumPremiums/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Opcional;^[A-Z]{3}$;;0;1;"";Não permitido;string;BRL;
 /data/defferalPeriod/minimumPremiums/periodicity;periodicity;;Texto;10;Opcional;;"DIARIO 
@@ -74,7 +84,7 @@ SEMESTRAL
 ANUAL 
 UNICO";0;1;"";Não permitido;string;MENSAL;
 /data/defferalPeriod/minimumPremiums/amount;amount;Valor mínimo em R$ de prêmio/ contribuição aceita pela sociedade ao plano (identificar valor mensal e/ou aporte único).;Texto;21;Opcional;^\d{1,16}\.\d{2,4}$;;0;1;"";Não permitido;string;250.00;
-/data/defferalPeriod/premiumPaymentMethods;premiumPaymentMethods;;Lista;27;Obrigatório;;"CARTAO_CREDITO 
+/data/defferalPeriod/premiumPaymentMethods;premiumPaymentMethods;;Lista;27;Opcional;;"CARTAO_CREDITO 
 DEBITO_CONTA 
 DEBITO_CONTA_POUPANCA 
 BOLETO_BANCARIO 
@@ -84,7 +94,7 @@ REGRA_PARCEIRO
 CONSIGNACAO_FOLHA_PAGAMENTO 
 PONTOS_PROGRAMA_BENEFICIO 
 TED_DOC 
-OUTROS";1;N;"";Não permitido;array;CARTAO_CREDITO;
+OUTROS";0;N;"";Não permitido;array;CARTAO_CREDITO;
 /data/defferalPeriod/permissionExtraordinaryContributions;permissionExtraordinaryContributions;"Se ficam permitidos aportes extraordinários. A considerar os seguintes domínios:
 1. true
 2. false
@@ -92,7 +102,7 @@ OUTROS";1;N;"";Não permitido;array;CARTAO_CREDITO;
 /data/defferalPeriod/permissionScheduledFinancialPayments;permissionScheduledFinancialPayments;"Se ficam permitidos pagamentos financeiros programados. A considerar os seguintes domínios:
 1. true
 2. false
-";Booleano;;Opcional;;;0;1;"";Não permitido;boolean;true;
+";Booleano;;Obrigatório;;;1;1;"";Não permitido;boolean;true;
 /data/defferalPeriod/gracePeriod;gracePeriod;Prazo de carência;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/defferalPeriod/gracePeriod/redemption;redemption;"Prazo em dias de carência para resgate Para Coletivos: Valor máximo da carência.
 ";Número;;Obrigatório;;;1;1;"";Não permitido;number;100;
@@ -100,24 +110,24 @@ OUTROS";1;N;"";Não permitido;array;CARTAO_CREDITO;
 ";Número;;Obrigatório;;;1;1;"";Não permitido;number;30;
 /data/defferalPeriod/gracePeriod/portability;portability;Prazo em dias de carência para portabilidade (entre empresas diferentes).;Número;;Obrigatório;;;1;1;"";Não permitido;number;12;
 /data/defferalPeriod/gracePeriod/betweenPortabilityRequests;betweenPortabilityRequests;Prazo em dias de carência entre pedidos de portabilidade (entre empresas diferentes).;Número;;Obrigatório;;;1;1;"";Não permitido;number;15;
-/data/defferalPeriod/redemptionPaymentTerm;redemptionPaymentTerm;Prazo em dias para pagamento do resgate;Inteiro;;Opcional;;;0;1;"";Não permitido;integer;10;
-/data/defferalPeriod/portabilityPaymentTerm;portabilityPaymentTerm;Prazo em dias para pagamento da portabilidade (entre empresas diferentes).;Número;;Opcional;;;0;1;"";Não permitido;number;20;
+/data/defferalPeriod/redemptionPaymentTerm;redemptionPaymentTerm;Prazo em dias para pagamento do resgate;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;10;
+/data/defferalPeriod/portabilityPaymentTerm;portabilityPaymentTerm;Prazo em dias para pagamento da portabilidade (entre empresas diferentes).;Número;;Obrigatório;;;1;1;"";Não permitido;number;20;
 /data/defferalPeriod/investmentFunds;investmentFunds;;Lista;;Opcional;;;0;N;"";Não permitido;array;;
-/data/defferalPeriod/investmentFunds/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Opcional;^\d{14}$;;0;1;"";Não permitido;string;13456789000112;
+/data/defferalPeriod/investmentFunds/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
 /data/defferalPeriod/investmentFunds/name;name;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
 - Nome Fantasia
-";Texto;80;Opcional;;;0;1;"";Não permitido;string;EMPRESAAPREV;
+";Texto;80;Obrigatório;;;1;1;"";Não permitido;string;EMPRESAAPREV;
 /data/defferalPeriod/investmentFunds/maximumAdministrationFee;maximumAdministrationFee;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
   - Taxa Máxima de Administração - em %
-";Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.201000;
+";Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/defferalPeriod/investmentFunds/typePerformanceFee;typePerformanceFee;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
    - Tipo de taxa de performance
-";Texto;13;Opcional;;"DIRETAMENTE 
+";Texto;13;Obrigatório;;"DIRETAMENTE 
 INDIRETAMENTE 
-NAO_APLICA";0;1;"";Não permitido;string;DIRETAMENTE;
+NAO_APLICA";1;1;"";Não permitido;string;DIRETAMENTE;
 /data/defferalPeriod/investmentFunds/maximumPerformanceFee;maximumPerformanceFee;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando: 
   - Taxa Máxima de Performance - em %
-";Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.201000;
+";Texto;8;Opcional;^\d{1}\.\d{6}$;;0;1;"";Não permitido;string;0.019800;8
 /data/defferalPeriod/investmentFunds/eligibilityRule;eligibilityRule;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
   - Regra de Elegibilidade
 ";Booleano;;Opcional;;;0;1;"";Não permitido;boolean;true;
@@ -128,7 +138,7 @@ NAO_APLICA";0;1;"";Não permitido;string;DIRETAMENTE;
   - Valor Mínimo do Saldo Provisão matemática
 ";Texto;21;Opcional;^\d{1,16}\.\d{2,4}$;;0;1;"";Não permitido;string;1000.00;
 /data/defferalPeriod/investmentFunds/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Opcional;^[A-Z]{3}$;;0;1;"";Não permitido;string;BRL;
-/data/grantPeriodBenefit;grantPeriodBenefit;Período de concessão do benefício;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
+/data/grantPeriodBenefit;grantPeriodBenefit;Período de concessão do benefício;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/grantPeriodBenefit/incomeModalities;incomeModalities;;Lista;;Obrigatório;;"PAGAMENTO_UNICO 
 RENDA_PRAZO_CERTO 
 RENDA_TEMPORARIA 
@@ -155,31 +165,32 @@ AT_83_MALE_FEMALE
 BR_EMSSB_MALE 
 BR_EMSSB_FEMALE 
 BR_EMSSB_MALE_FEMALE";0;N;"";Não permitido;array;AT_2000_MALE;
-/data/grantPeriodBenefit/interestRate;interestRate;Taxa de juros garantida utilizada para conversão em renda. Em %;Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.225222;
+/data/grantPeriodBenefit/interestRate;interestRate;Taxa de juros garantida utilizada para conversão em renda. Em %;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/grantPeriodBenefit/updateIndex;updateIndex;"Índice utilizado na atualização do prêmio e do capital segurado, caso critério de atualização por meio de índice:
 1. IPCA (IBGE);
 2. IGP-M (FGV);
 3. INPC (IBGE).
-";Texto;5;Opcional;;"IPCA 
+";Texto;5;Obrigatório;;"IPCA 
 IGP_M 
-INPC";0;1;"";Não permitido;string;IPCA;
-/data/grantPeriodBenefit/reversalFinancialResults;reversalFinancialResults;Percentual de reversão de excedente financeiro na concessão. Em %.;Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;1.252111;
+INPC 
+NAO_SE_APLICA";1;1;"";Não permitido;string;IPCA;
+/data/grantPeriodBenefit/reversalFinancialResults;reversalFinancialResults;Percentual de reversão de excedente financeiro na concessão. Em %.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/grantPeriodBenefit/investmentFunds;investmentFunds;;Lista;;Opcional;;;0;N;"";Não permitido;array;;
-/data/grantPeriodBenefit/investmentFunds/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Opcional;^\d{14}$;;0;1;"";Não permitido;string;13456789000112;
+/data/grantPeriodBenefit/investmentFunds/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
 /data/grantPeriodBenefit/investmentFunds/name;name;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
 - Nome Fantasia
-";Texto;80;Opcional;;;0;1;"";Não permitido;string;EMPRESAAPREV;
+";Texto;80;Obrigatório;;;1;1;"";Não permitido;string;EMPRESAAPREV;
 /data/grantPeriodBenefit/investmentFunds/maximumAdministrationFee;maximumAdministrationFee;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
   - Taxa Máxima de Administração - em %
-";Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.201000;
+";Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/grantPeriodBenefit/investmentFunds/typePerformanceFee;typePerformanceFee;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
    - Tipo de taxa de performance
-";Texto;13;Opcional;;"DIRETAMENTE 
+";Texto;13;Obrigatório;;"DIRETAMENTE 
 INDIRETAMENTE 
-NAO_APLICA";0;1;"";Não permitido;string;DIRETAMENTE;
+NAO_APLICA";1;1;"";Não permitido;string;DIRETAMENTE;
 /data/grantPeriodBenefit/investmentFunds/maximumPerformanceFee;maximumPerformanceFee;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando: 
   - Taxa Máxima de Performance - em %
-";Texto;8;Opcional;^[0-1]\.\d{6}$;;0;1;"";Não permitido;string;0.201000;
+";Texto;8;Opcional;^\d{1}\.\d{6}$;;0;1;"";Não permitido;string;0.019800;8
 /data/grantPeriodBenefit/investmentFunds/eligibilityRule;eligibilityRule;"Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
   - Regra de Elegibilidade
 ";Booleano;;Opcional;;;0;1;"";Não permitido;boolean;true;
@@ -190,31 +201,29 @@ NAO_APLICA";0;1;"";Não permitido;string;DIRETAMENTE;
   - Valor Mínimo do Saldo Provisão matemática
 ";Texto;21;Opcional;^\d{1,16}\.\d{2,4}$;;0;1;"";Não permitido;string;1000.00;
 /data/grantPeriodBenefit/investmentFunds/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Opcional;^[A-Z]{3}$;;0;1;"";Não permitido;string;BRL;
-/data/costs;costs;Custos;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
+/data/costs;costs;Custos;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/costs/loadingAntecipated;loadingAntecipated;Carregamento antecipado.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
-/data/costs/loadingAntecipated/minValue;minValue;Percentual mínimo de carregamento cobrada quando do pagamento do prêmio/ contribuição. Em %.;Texto;8;Obrigatório;^[0-1]\.\d{6}$;;1;1;"";Não permitido;string;0.000000;
-/data/costs/loadingAntecipated/maxValue;maxValue;Percentual máximo de carregamento cobrada quando do pagamento do prêmio/ contribuição. Em %.;Texto;8;Obrigatório;^[0-1]\.\d{6}$;;1;1;"";Não permitido;string;0.100000;
+/data/costs/loadingAntecipated/minValue;minValue;Percentual mínimo de carregamento cobrada quando do pagamento do prêmio/ contribuição. Em %.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
+/data/costs/loadingAntecipated/maxValue;maxValue;Percentual máximo de carregamento cobrada quando do pagamento do prêmio/ contribuição. Em %.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/costs/loadingLate;loadingLate;Carregamento postecipado.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
-/data/costs/loadingLate/minValue;minValue;Percentual mínimo de taxa de carregamento cobrado quando da efetivação de resgate ou portabilidade.;Texto;8;Obrigatório;^[0-1]\.\d{6}$;;1;1;"";Não permitido;string;0.000000;
-/data/costs/loadingLate/maxValue;maxValue;Percentual máximo de taxa de carregamento cobrado quando da efetivação de resgate ou portabilidade.;Texto;8;Obrigatório;^[0-1]\.\d{6}$;;1;1;"";Não permitido;string;0.100000;
+/data/costs/loadingLate/minValue;minValue;Percentual mínimo de taxa de carregamento cobrado quando da efetivação de resgate ou portabilidade.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
+/data/costs/loadingLate/maxValue;maxValue;Percentual máximo de taxa de carregamento cobrado quando da efetivação de resgate ou portabilidade.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
 /data/minimumRequirement;minimumRequirement;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/minimumRequirement/contractType;contractType;"O tipo de serviço contratado. A considerar os domínios abaixo:
 1. Coletivo Averbado;
-2. Individual.
-3. Ambas
-";Texto;27;Obrigatório;;"COLETIVO 
-INDIVIDUAL 
-AMBAS";1;1;"";Não permitido;string;COLETIVO;
+2. Coletivo instituído;
+3. Individual.
+";Texto;27;Obrigatório;;"COLETIVO_AVERBADO 
+COLETIVO_INSTITUIDO 
+INDIVIDUAL";1;1;"";Não permitido;string;COLETIVO_AVERBADO;
 /data/minimumRequirement/participantQualified;participantQualified;"Indicação se o plano é destinado para participante qualificado. A considerar os domínios abaixo:
 1. true
 2. false
 ";Booleano;;Obrigatório;;;1;1;"";Não permitido;boolean;true;
-/data/minimumRequirement/contractingMinRequirement;contractingMinRequirement;Campo aberto (possibilidade de incluir URL);Texto;1024;Opcional;;;0;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
+/data/minimumRequirement/contractingMinRequirement;contractingMinRequirement;Campo aberto (possibilidade de incluir URL);Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/targetAudience;targetAudience;"A considerar os domínios abaixo:
 
   1. Pessoa Natural
   2. Pessoa Jurídica
-  3. Ambas (Pessoa Natural e Jurídica)
 ";Texto;23;Obrigatório;;"PESSOA_NATURAL 
-PESSOA_JURIDICA 
-PESSOA_NATURAL_JURIDICA";1;1;"";Não permitido;string;PESSOA_NATURAL;
+PESSOA_JURIDICA";1;1;"";Não permitido;string;PESSOA_NATURAL;

--- a/swagger-apis/pension/1.0.0-rc2.0.yml
+++ b/swagger-apis/pension/1.0.0-rc2.0.yml
@@ -46,6 +46,8 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '529':
+          $ref: '#/components/responses/SiteIsOverloaded'
   /survival-coverages:
     get:
       tags:
@@ -69,6 +71,8 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '529':
+          $ref: '#/components/responses/SiteIsOverloaded'
 components:
   schemas:
     OKResponseRiskCoveragePension:
@@ -94,17 +98,51 @@ components:
         - society
         - name
         - code
+        - modality
         - coverages
-        - assistanceTypes
-        - additionals
         - termsAndConditions
-        - terms
-        - benefitRecalculation
-        - premiumPayment
+        - premiumUpdateIndex
+        - otherGuaranteedValues
+        - contributionPayment
+        - minimumRequirement
         - targetAudience
       properties:
         participant:
-          $ref: '#/components/schemas/Participant'
+          type: object
+          description: Conjunto de informações relativas ao participante do produto de Open Finance
+          required:
+            - brand
+            - name
+            - cnpjNumber
+          properties:
+            brand:
+              type: string
+              description: 'Nome da marca reportada pelo participante do Open Finance. O conceito a que se refere a ''marca'' é em essência uma promessa da empresa em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.'
+              maxLength: 80
+              example: Organização
+            name:
+              type: string
+              description: Nome do participante do Open Finance.
+              maxLength: 80
+              example: Organização A1
+            cnpjNumber:
+              $ref: '#/components/schemas/CnpjNumber'
+            urlComplementaryList:
+              description: |
+                Espera-se que valor de retorno, após acesso ao link ‘urlComplementaryList’, deve ser array de objeto com a estrutura abaixo:
+
+                - ‘name’ com o valor contido no campo ‘LegalEntityName’ conforme cadastro no diretório;
+
+                - ‘cnpjNumber’ com o valor contido no campo CNPJ (‘RegistrationNumber’) correspondente a esta instituição;
+
+                - Ambos do tipo string;
+
+                - Ambos obrigatórios.
+              type: string
+              maxLength: 1024
+              pattern: '^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$'
+              example: 'https://empresaa1.com/companies'
+          additionalProperties: false
         society:
           type: object
           description: Conjunto de informações relativas à seguradora do produto de open insurance
@@ -150,59 +188,43 @@ components:
           description: Lista a ser preenchida pelas participantes quando houver 'Outros' no campo 'Tipo de Assistência'.
           example:
             - Assistance additional info.
-        additionals:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumAdditional'
-          example:
-            - SORTEIO
-            - OUTROS
+        additional:
+          $ref: '#/components/schemas/EnumAdditional'
         termsAndConditions:
           type: array
           items:
             $ref: '#/components/schemas/TermsAndConditions'
           minItems: 1
         pmbacRemuneration:
-          $ref: '#/components/schemas/InsurancePensionEnumPmbacRemuneration'
+          $ref: '#/components/schemas/RiskPensionEnumPmbacRemuneration'
+        premiumUpdateIndex:
+          $ref: '#/components/schemas/RiskPensionEnumPremiumUpdateIndex'
         ageAdjustment:
           $ref: '#/components/schemas/AgeAdjustment'
-        financialRegimeContractTypes:
-          type: array
-          items:
-            $ref: '#/components/schemas/InsurancePensionEnumFinancialRegime'
+        financialRegimeContractType:
+          $ref: '#/components/schemas/RiskPensionEnumFinancialRegime'
         reclaim:
-          $ref: '#/components/schemas/InsurancePensionReclaim'
+          $ref: '#/components/schemas/RiskPensionReclaim'
         otherGuaranteedValues:
-          type: array
-          items:
-            type: string
-            description: |
-              1. Saldamento
-              2. Benefício Prolongado
-              3. Não se aplica
-            maxLength: 20
-            enum:
-              - SALDAMENTO
-              - BENEFICIO_PROLONGADO
-              - NAO_APLICA
-            example: SALDAMENTO
-        indemnityPaymentMethods:
-          type: array
-          items:
-            type: string
-            description: |
-              Modalidade de pagamento da indenização, a considerar os domínios abaixo:
-                1. Único
-                2. Sob a forma de renda
-            maxLength: 18
-            enum:
-              - UNICO
-              - SOB_FORMA_RENDA
-            example: UNICO
+          $ref: '#/components/schemas/RiskPensionEnumOtherGuaranteedValues'
+        contributionPayment:
+          $ref: '#/components/schemas/RiskPensionEnumContributionPayment'
         minimumRequirement:
           $ref: '#/components/schemas/RiskPensionMinimumRequirement'
         targetAudience:
-          $ref: '#/components/schemas/EnumTargetAudience'
+          type: string
+          description: |
+            A considerar os domínios abaixo:
+
+              1. Pessoa Natural
+              2. Pessoa Jurídica
+              3. Ambas (Pessoa Natural e Jurídica)
+          maxLength: 23
+          enum:
+            - PESSOA_NATURAL
+            - PESSOA_JURIDICA
+            - PESSOA_NATURAL_JURIDICA
+          example: PESSOA_NATURAL
       additionalProperties: false
     OKResponseSurvivalCoveragePension:
       type: object
@@ -227,11 +249,14 @@ components:
         - name
         - code
         - segment
-        - type
+        - modality
+        - defferalPeriod
+        - grantPeriodBenefit
+        - costs
         - targetAudience
       properties:
         participant:
-          $ref: '#/components/schemas/Participant'
+          $ref: '#/components/schemas/GetRiskPensionContractData/properties/participant'
         society:
           $ref: '#/components/schemas/GetRiskPensionContractData/properties/society'
         name:
@@ -288,11 +313,16 @@ components:
         minimumRequirement:
           $ref: '#/components/schemas/SurvivalPensionMinimumRequirements'
         targetAudience:
-          $ref: '#/components/schemas/EnumTargetAudience'
+          $ref: '#/components/schemas/SurvivalPensionEnumTargetAudience'
       additionalProperties: false
     SurvivalPensionInvestmentFund:
       type: object
       description: Fundos de Investimento (por fundo).
+      required:
+        - cnpjNumber
+        - name
+        - maximumAdministrationFee
+        - typePerformanceFee
       properties:
         cnpjNumber:
           $ref: '#/components/schemas/CnpjNumber'
@@ -305,12 +335,13 @@ components:
           example: EMPRESAAPREV
         maximumAdministrationFee:
           type: string
-          pattern: '^[0-1]\.\d{6}$'
+          pattern: '^\d{1}\.\d{6}$'
           description: |
             Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando:
               - Taxa Máxima de Administração - em %
-          example: '0.201000'
+          example: '0.019800'
           maxLength: 8
+          minLength: 8
         typePerformanceFee:
           type: string
           enum:
@@ -324,12 +355,13 @@ components:
           maxLength: 13
         maximumPerformanceFee:
           type: string
-          pattern: '^[0-1]\.\d{6}$'
+          pattern: '^\d{1}\.\d{6}$'
           description: |
             Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação, contemplando: 
               - Taxa Máxima de Performance - em %
           maxLength: 8
-          example: '0.201000'
+          minLength: 8
+          example: '0.019800'
         eligibilityRule:
           type: boolean
           description: |
@@ -360,20 +392,21 @@ components:
       required:
         - contractType
         - participantQualified
+        - contractingMinRequirement
       properties:
         contractType:
           type: string
           maxLength: 27
           enum:
-            - COLETIVO
+            - COLETIVO_AVERBADO
+            - COLETIVO_INSTITUIDO
             - INDIVIDUAL
-            - AMBAS
           description: |
             O tipo de serviço contratado. A considerar os domínios abaixo:
             1. Coletivo Averbado;
-            2. Individual.
-            3. Ambas
-          example: COLETIVO
+            2. Coletivo instituído;
+            3. Individual.
+          example: COLETIVO_AVERBADO
         participantQualified:
           type: boolean
           description: |
@@ -391,7 +424,7 @@ components:
       type: string
       description: 'Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.'
       maxLength: 20
-      pattern: '^\d{5}\.\d{6}/\d{4}-\d{2}$'
+      pattern: '^\d{5}\.\d{6}\/\d{4}-\d{2}$|^\d{2}\.\d{6}\/\d{2}-\d{2}$|^\d{3}-\d{5}\/\d{2}$|^\d{5}\.\d{6}\/\d{2}-\d{2}$'
       example: 15414.622222/2222-22
     CnpjNumber:
       type: string
@@ -402,14 +435,21 @@ components:
       type: object
       description: Período de Diferimento
       required:
-        - premiumPaymentMethods
+        - interestRate
+        - updateIndex
+        - otherMinimumPerformanceGarantees
+        - reversalFinancialResults
+        - permissionScheduledFinancialPayments
+        - redemptionPaymentTerm
+        - portabilityPaymentTerm
       properties:
         interestRate:
           type: string
           maxLength: 8
-          pattern: '^[0-1]\.\d{6}$'
+          minLength: 8
+          pattern: '^\d{1}\.\d{6}$'
           description: Taxa de juros mensal garantida que remunera o plano durante a fase de diferimento/acumulação.
-          example: '0.251231'
+          example: '0.019800'
         updateIndex:
           $ref: '#/components/schemas/UpdateIndex'
         otherMinimumPerformanceGarantees:
@@ -420,9 +460,10 @@ components:
         reversalFinancialResults:
           type: string
           maxLength: 8
-          pattern: '^[0-1]\.\d{6}$'
+          minLength: 8
+          pattern: '^\d{1}\.\d{6}$'
           description: Percentual de reversão de excedente financeiro na concessão. Em %.
-          example: '0.051230'
+          example: '0.019800'
         minimumPremiums:
           type: array
           items:
@@ -560,16 +601,18 @@ components:
       properties:
         minValue:
           type: string
-          pattern: '^[0-1]\.\d{6}$'
+          pattern: '^\d{1}\.\d{6}$'
           maxLength: 8
+          minLength: 8
           description: Percentual mínimo de carregamento cobrada quando do pagamento do prêmio/ contribuição. Em %.
-          example: '0.000000'
+          example: '0.019800'
         maxValue:
           type: string
-          pattern: '^[0-1]\.\d{6}$'
+          pattern: '^\d{1}\.\d{6}$'
           maxLength: 8
+          minLength: 8
           description: Percentual máximo de carregamento cobrada quando do pagamento do prêmio/ contribuição. Em %.
-          example: '0.100000'
+          example: '0.019800'
       additionalProperties: false
     SurvivalPensionLoadingLate:
       type: object
@@ -580,16 +623,18 @@ components:
       properties:
         minValue:
           type: string
-          pattern: '^[0-1]\.\d{6}$'
+          pattern: '^\d{1}\.\d{6}$'
           maxLength: 8
+          minLength: 8
           description: Percentual mínimo de taxa de carregamento cobrado quando da efetivação de resgate ou portabilidade.
-          example: '0.000000'
+          example: '0.019800'
         maxValue:
           type: string
-          pattern: '^[0-1]\.\d{6}$'
+          pattern: '^\d{1}\.\d{6}$'
           maxLength: 8
+          minLength: 8
           description: Percentual máximo de taxa de carregamento cobrado quando da efetivação de resgate ou portabilidade.
-          example: '0.100000'
+          example: '0.019800'
       additionalProperties: false
     SurvivalPensionMinimumPremium:
       type: object
@@ -623,6 +668,9 @@ components:
       description: Período de concessão do benefício
       required:
         - incomeModalities
+        - interestRate
+        - updateIndex
+        - reversalFinancialResults
       properties:
         incomeModalities:
           type: array
@@ -685,17 +733,19 @@ components:
         interestRate:
           type: string
           maxLength: 8
-          pattern: '^[0-1]\.\d{6}$'
+          minLength: 8
+          pattern: '^\d{1}\.\d{6}$'
           description: Taxa de juros garantida utilizada para conversão em renda. Em %
-          example: '0.225222'
+          example: '0.019800'
         updateIndex:
           $ref: '#/components/schemas/UpdateIndex'
         reversalFinancialResults:
           type: string
           maxLength: 8
-          pattern: '^[0-1]\.\d{6}$'
+          minLength: 8
+          pattern: '^\d{1}\.\d{6}$'
           description: Percentual de reversão de excedente financeiro na concessão. Em %.
-          example: '1.252111'
+          example: '0.019800'
         investmentFunds:
           type: array
           items:
@@ -780,38 +830,48 @@ components:
           maxLength: 80
           example: Organização A1
         cnpjNumber:
-          $ref: '#/components/schemas/CnpjNumber'
+          type: string
+          description: 'O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.'
+          pattern: '^\d{14}$'
+          example: '13456789000112'
         urlComplementaryList:
+          description: |
+            Espera-se que valor de retorno, após acesso ao link ‘urlComplementaryList’, deve ser array de objeto com a estrutura abaixo:
+
+            - 'name' com o valor contido no campo ‘LegalEntityName’ conforme cadastro no diretório;
+
+            - 'cnpjNumber' com o valor contido no campo CNPJ (‘RegistrationNumber’) correspondente a esta instituição;
+
+            - Ambos do tipo string;
+
+            - Ambos obrigatórios. 
           type: string
           maxLength: 1024
           pattern: '^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$'
           example: 'https://empresaa1.com/companies'
       additionalProperties: false
-    InsurancePensionEnumIndemnifiablePeriodType:
+    RiskPensionEnumIndemnifiablePeriodType:
       type: string
       description: |
         Listagem do pagamento para cada benefício:
           1. Quantidade determinada de parcelas;
           2. Até o fim de ciclo determinado.
         Se for pagamento único, esse campo não se aplica (retorna vazio).
-      maxLength: 31
       enum:
         - QUANTIDADE_DETERMINADA_PARCELAS
         - FIM_CICLO_DETERMINADO
       example: QUANTIDADE_DETERMINADA_PARCELAS
-    EnumTargetAudience:
+    SurvivalPensionEnumTargetAudience:
       type: string
       description: |
         A considerar os domínios abaixo:
 
           1. Pessoa Natural
           2. Pessoa Jurídica
-          3. Ambas (Pessoa Natural e Jurídica)
       maxLength: 23
       enum:
         - PESSOA_NATURAL
         - PESSOA_JURIDICA
-        - PESSOA_NATURAL_JURIDICA
       example: PESSOA_NATURAL
     EnumProductModality:
       type: string
@@ -840,7 +900,6 @@ components:
       type: object
       required:
         - type
-        - attributes
       properties:
         type:
           $ref: '#/components/schemas/EnumRiskPensionCoverageType'
@@ -874,16 +933,37 @@ components:
       required:
         - minValue
         - maxValue
+        - indemnifiableDeadline
+        - indemnityPaymentMethod
         - gracePeriod
+        - excludedRisks
+        - excludedRisksURL
+        - profitModality
       properties:
         minValue:
           $ref: '#/components/schemas/InsurancePensionMinValue'
         maxValue:
           $ref: '#/components/schemas/InsurancePensionMaxValue'
-        indemnifiablePeriods:
-          type: array
-          items:
-            $ref: '#/components/schemas/InsurancePensionEnumIndemnifiablePeriodType'
+        indemnifiablePeriod:
+          $ref: '#/components/schemas/RiskPensionEnumIndemnifiablePeriodType'
+        indemnifiableDeadline:
+          type: integer
+          description: Número máximo de parcelas indenizáveis. Caso seja relacionado a parcelas.
+        indemnityPaymentMethod:
+          $ref: '#/components/schemas/RiskPensionEnumIndemnityPaymentMethod'
+        gracePeriod:
+          type: object
+          description: Período de carência da cobertura
+          properties:
+            amount:
+              type: integer
+              format: int64
+              description: Informar o prazo de carência
+              example: 90
+              maximum: 9999999999
+            unit:
+              $ref: '#/components/schemas/EnumGracePeriodUnit'
+          additionalProperties: false
         excludedRisks:
           type: array
           items:
@@ -893,8 +973,10 @@ components:
           maxLength: 1024
           description: Campo aberto (possibilidade de incluir URL).
           example: 'https://openinsurance.com.br/aaa'
+        profitModality:
+          $ref: '#/components/schemas/RiskPensionEnumProfitModality'
       additionalProperties: false
-    GracePeriod:
+    RiskPensionGracePeriod:
       type: object
       required:
         - amount
@@ -907,7 +989,7 @@ components:
           example: 90
           maximum: 9999999999
         unit:
-          $ref: '#/components/schemas/EnumGracePeriodUnit'
+          $ref: '#/components/schemas/RiskPensionEnumGracePeriodUnit'
       additionalProperties: false
     TermsAndConditions:
       type: object
@@ -916,7 +998,12 @@ components:
         - detail
       properties:
         susepProcessNumber:
-          $ref: '#/components/schemas/SusepProcessNumber'
+          type: string
+          description: 'Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.'
+          minLength: 12
+          maxLength: 20
+          pattern: '^\d{5}\.\d{6}\/\d{4}-\d{2}$|^\d{2}\.\d{6}\/\d{2}-\d{2}$|^\d{3}-\d{5}\/\d{2}$|^\d{5}\.\d{6}\/\d{2}-\d{2}$'
+          example: 15414.622222/2222-22
         detail:
           type: string
           description: 'Representam as Condições Gerais, Condições Especiais e Condições ou Cláusulas Particulares de um mesmo produto. (Circular SUSEP 321/06). Campo aberto (possibilidade de incluir URL)'
@@ -935,17 +1022,20 @@ components:
         - IPCA
         - IGP_M
         - INPC
+        - NAO_SE_APLICA
       example: IPCA
-    InsurancePensionReclaim:
+    RiskPensionReclaim:
       type: object
+      required:
+        - gracePeriod
       properties:
         table:
           type: array
           items:
-            $ref: '#/components/schemas/InsurancePensionReclaimTableItem'
+            $ref: '#/components/schemas/RiskPensionReclaimTableItem'
           minItems: 1
         gracePeriod:
-          $ref: '#/components/schemas/GracePeriod'
+          $ref: '#/components/schemas/RiskPensionGracePeriod'
         differenciatedPercentage:
           description: Campo aberto (possibilidade de incluir URL)
           example: |
@@ -988,23 +1078,30 @@ components:
       type: object
       required:
         - contractType
+        - contractingMinRequirement
       properties:
         contractType:
           type: string
-          description: O tipo de serviço contratado. A considerar os domínios abaixo&#58;<br><ol><li>Coletivo Averbado</li><li>Coletivo Instituído</li><li>Individual</li></ol>
+          description: |
+            O tipo de serviço contratado. A considerar os domínios abaixo:
+            1. Coletivo;
+            2. Individual.
           enum:
-            - COLETIVO_AVERBADO
-            - COLETIVO_INSTITUIDO
+            - COLETIVO
             - INDIVIDUAL
-          example: COLETIVO_AVERBADO
+          example: COLETIVO
         contractingMinRequirement:
           type: string
           description: Campo aberto contendo todos os requisitos mínimos para contratação (possibilidade de incluir URL).
           maxLength: 1024
           example: 'https://openinsurance.com.br/aaa'
       additionalProperties: false
-    InsurancePensionReclaimTableItem:
+    RiskPensionReclaimTableItem:
       type: object
+      required:
+        - initialMonthRange
+        - finalMonthRange
+        - percentage
       properties:
         initialMonthRange:
           type: integer
@@ -1016,19 +1113,24 @@ components:
           example: 12
         percentage:
           type: string
-          pattern: '^\d\.\d{4}$'
+          pattern: '^\d{1}\.\d{6}$'
+          maxLength: 8
+          minLength: 8
           description: Percentual de faixa de resgate.
-          maxLength: 6
-          example: '0.5000'
+          example: '0.019800'
       additionalProperties: false
-    InsurancePensionEnumPmbacRemuneration:
+    RiskPensionEnumPmbacRemuneration:
       type: object
+      required:
+        - interestRate
       properties:
         interestRate:
           type: string
-          pattern: '^\d{1,16}\.\d{4}$'
+          pattern: '^\d{1}\.\d{6}$'
           description: Taxa de juros para capitalização da PMBaC
-          example: '14.2521'
+          maxLength: 8
+          minLength: 8
+          example: '0.019800'
         updateIndexes:
           type: array
           items:
@@ -1159,7 +1261,6 @@ components:
       example: ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA
     EnumAdditional:
       type: string
-      maxLength: 44
       enum:
         - SORTEIO
         - SERVICOS_ASSISTENCIAS_COMPLEMENTARES_PAGO
@@ -1176,19 +1277,137 @@ components:
         - MESES
         - NAO_APLICA
       example: MESES
-    InsurancePensionEnumFinancialRegime:
+    RiskPensionEnumGracePeriodUnit:
+      type: string
+      description: |
+        Informar o critério de carência para resgate:
+        1. Dias;
+        2. Meses;
+        3. Não se aplica.
+      enum:
+        - DIAS
+        - MESES
+        - NAO_APLICA
+      example: MESES
+    RiskPensionEnumFinancialRegime:
       type: string
       description: |
         Listagem de regime financeiro para cada combinação de modalidade/cobertura do produto indicando:
           1. Repartição simples
           2. Repartição Capitais Cobertura
           3. Capitalização
-      maxLength: 19
       example: REPARTICAO_SIMPLES
       enum:
         - REPARTICAO_SIMPLES
         - REPARTICAO_CAPITAIS
         - CAPITALIZACAO
+    RiskPensionEnumPremiumUpdateIndex:
+      type: string
+      description: Índice utilizado na atualização do prêmio/contribuição e do capital segurado/benefício
+      enum:
+        - IPCA
+        - IGPM
+        - INPC
+      example: IPCA
+    RiskPensionEnumContributionPayment:
+      type: object
+      description: Pagamento da contribuição.
+      required:
+        - contributionPaymentMethod
+        - contributionPeriodicity
+      properties:
+        contributionPaymentMethod:
+          type: string
+          example: CARTAO_CREDITO
+          description: |
+            Forma de pagamento da contribuição.
+             - CARTAO_CREDITO
+             - DEBITO_CONTA
+             - DEBITO_CONTA_POUPANCA
+             - BOLETO_BANCARIO
+             - PIX
+             - TED_DOC
+             - CONSIGNACAO_FOLHA_PAGAMENTO
+             - PONTOS_PROGRAMA_BENEFICIO
+             - OUTROS
+          enum:
+            - CARTAO_CREDITO
+            - DEBITO_CONTA
+            - DEBITO_CONTA_POUPANCA
+            - BOLETO_BANCARIO
+            - PIX
+            - TED_DOC
+            - CONSIGNACAO_FOLHA_PAGAMENTO
+            - PONTOS_PROGRAMA_BENEFICIO
+            - OUTROS
+        contributionPaymentMethodAdditionalInfo:
+          type: string
+          pattern: '[\w\W\s]*'
+          example: Informações adicionais
+          maxLength: 140
+          description: |
+            Campo livre para preenchimento das informações adicionais referente ao contributionPaymentMethod.
+
+            [Restrição] Obrigatório quando 'contributionPaymentMethod' for igual 'OUTROS'. 
+        contributionPeriodicity:
+          type: string
+          example: MENSAL
+          description: |
+            Periodicidade de pagamento da contribuição.
+            - MENSAL
+            - UNICA
+            - ANUAL
+            - TRIMESTRAL
+            - SEMESTRAL
+            - BIMESTRAL
+            - OUTROS
+          enum:
+            - MENSAL
+            - UNICA
+            - ANUAL
+            - TRIMESTRAL
+            - SEMESTRAL
+            - BIMESTRAL
+            - OUTROS
+        contributionPeriodicityAdditionalInfo:
+          type: string
+          pattern: '[\w\W\s]*'
+          example: Informações adicionais
+          maxLength: 140
+          description: |
+            Campo livre para preenchimento das informações adicionais referente ao contributionPaymentMethod.
+
+            [Restrição] Obrigatório quando 'contributionPeriodicity' for igual 'OUTROS'.
+      additionalProperties: false
+    RiskPensionEnumIndemnityPaymentMethod:
+      type: string
+      description: |
+        Modalidade de pagamento da indenização, a considerar os domínios abaixo:
+          1. Único
+          2. Sob a forma de renda
+      enum:
+        - UNICO
+        - SOB_FORMA_RENDA
+      example: UNICO
+    RiskPensionEnumOtherGuaranteedValues:
+      type: string
+      description: |
+        1. Saldamento
+        2. Benefício Prolongado
+        3. Não se aplica
+      enum:
+        - SALDAMENTO
+        - BENEFICIO_PROLONGADO
+        - NAO_APLICA
+      example: SALDAMENTO
+    RiskPensionEnumProfitModality:
+      type: string
+      description: |
+        Modalidade de pagamento da indenização.
+      enum:
+        - PAGAMENTO_UNICO
+        - FORMA_RENDA
+      example: PAGAMENTO_UNICO
   parameters:
     page:
       name: page
@@ -1275,7 +1494,7 @@ components:
           schema:
             $ref: '#/components/responses/NotFound/content/application~1json%3B%20charset%3Dutf-8/schema'
     TooManyRequests:
-      description: 'A operação foi recusada, pois muitas solicitações foram feitas dentro de um determinado período ou o limite global de requisições concorrentes foi atingido'
+      description: 'A operação foi recusada, pois muitas solicitações foram feitas dentro de um determinado período ou o limite de requisições concorrentes foi atingido.'
       content:
         application/json; charset=utf-8:
           schema:
@@ -1286,3 +1505,50 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/responses/NotFound/content/application~1json%3B%20charset%3Dutf-8/schema'
+    SiteIsOverloaded:
+      description: 'O site está sobrecarregado e a operação foi recusada, pois foi atingido o limite máximo de TPS global, neste momento.'
+      content:
+        application/json; charset=utf-8:
+          schema:
+            type: object
+            required:
+              - errors
+            properties:
+              errors:
+                type: array
+                minItems: 1
+                maxItems: 13
+                items:
+                  type: object
+                  required:
+                    - code
+                    - title
+                    - detail
+                  properties:
+                    code:
+                      description: Código de erro específico do endpoint
+                      type: string
+                      pattern: '[\w\W\s]*'
+                      maxLength: 255
+                    title:
+                      description: Título legível por humanos deste erro específico
+                      type: string
+                      pattern: '[\w\W\s]*'
+                      maxLength: 255
+                    detail:
+                      description: Descrição legível por humanos deste erro específico
+                      type: string
+                      pattern: '[\w\W\s]*'
+                      maxLength: 2048
+              meta:
+                type: object
+                description: Meta informações referente à API requisitada.
+                required:
+                  - requestDateTime
+                properties:
+                  requestDateTime:
+                    description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+                    type: string
+                    maxLength: 20
+                    format: date-time
+                    example: '2021-05-21T08:30:00Z'


### PR DESCRIPTION
#### Feat(Pension)
- PC50: Criar campos obrigatórios na API de Previdência endpoint “risk-coverages”;
- PC54: Modificar a obrigatoriedade de campos para seguir o Open Insurance e garantir a interoperabilidade;
- PC55: Ajuste em enums na API de Previdência endpoint “survival-coverages”;
- PC57: Modificar para obrigatório o campo “200/data/modality” para seguir o Open Insurance e permitir a interoperabilidade;
- PC58: Alterar o campo “data/minimumRequirement/contractType” ajustando a descrição e as opções do enum;
- PC59: Correções no objeto “data//reclaim/gracePeriod”;
- PC60: Criar o campo “gracePeriod” do tipo objeto obrigatório, conforme segue (acima do campo excludedRisks, dentro de “attributes”);
- PC62: Modificar o local do campo “indemnityPaymentMethods” para colocar dentro da estrutura de coverages do OFB (abaixo da Description);