### PR TITLE
GT-C - Dados abertos - Feat(Insurances) - PC67, PC68, PC69, PC70, PC71, PC72 e PC73 

### DIFF
--- a/dictionary/getPersonalInsurance_v1.csv
+++ b/dictionary/getPersonalInsurance_v1.csv
@@ -4,15 +4,21 @@
 /data/participant/brand;brand;Nome da marca reportada pelo participante do Open Finance. O conceito a que se refere a 'marca' é em essência uma promessa da empresa em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Organização;
 /data/participant/name;name;Nome do participante do Open Finance.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Organização A1;
 /data/participant/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
-/data/participant/urlComplementaryList;urlComplementaryList;;Texto;1024;Opcional;^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$;;0;1;"";Não permitido;string;https://empresaa1.com/companies;
+/data/participant/urlComplementaryList;urlComplementaryList;"Espera-se que valor de retorno, após acesso ao link 'urlComplementaryList', deve ser array de objeto com a estrutura abaixo:
+- 'name' com o valor contido no campo 'LegalEntityName' conforme cadastro no diretório;
+- 'cnpjNumber' com o valor contido no campo CNPJ ('RegistrationNumber') correspondente a esta instituição;
+- Ambos do tipo string;
+- Ambos obrigatórios. 
+";Texto;1024;Opcional;^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$;;0;1;"";Não permitido;string;https://empresaa1.com/companies;
 /data/society;society;Conjunto de informações relativas à seguradora do produto de open insurance;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/society/name;name;Nome da Sociedade Seguradora.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Society A1;
 /data/society/cnpjNumber;cnpjNumber;O CNPJ corresponde ao número de inscrição no Cadastro de Pessoa Jurídica. Deve-se ter apenas os números do CNPJ, sem máscara.;Texto;;Obrigatório;^\d{14}$;;1;1;"";Não permitido;string;13456789000112;
+/data/society/brand;brand;Nome da marca reportada pela sociedade seguradora participante do Open Finance. O conceito a que se refere a marca é em essência uma promessa das sociedades sob ela em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Marca;
 /data/name;name;Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;Produto A;
 /data/code;code;Código único a ser definido pela sociedade.;Texto;80;Obrigatório;;;1;1;"";Não permitido;string;0001;
 /data/category;category;"Indicar a categoria do Produto&#58;<br><ol><li>Tradicional</li><li>Microsseguro</li></ol>";Texto;12;Opcional;;"TRADICIONAL 
 MICROSSEGURO";0;1;"";Não permitido;string;TRADICIONAL;
-/data/modality;modality;<ol><li>Funeral</li><li>Prestamista (exceto Habitacional e Rural)</li><li>Viagem</li><li>Educacional</li><li>Dotal (Misto e Puro)</li><li>Acidentes Pessoais</li><li>Vida</li><li>Perda do Certificado de Habilitação de Voo – PCHV</li><li>Doenças Graves ou Doença Terminal</li><li>Desemprego/ Perda de Renda</li><li>Eventos Aleatórios</li><li>Pecúlio</li><li>Pensão prazo certo</li><li>Pensão menores 21 anos</li><li>Pensão menores 24 anos</li><li>Pensão cônjuge vitalícia</li><li>Pensão cônjuge temporária</li></ol>;Texto;33;Opcional;;"FUNERAL 
+/data/modality;modality;<ol><li>Funeral</li><li>Prestamista (exceto Habitacional e Rural)</li><li>Viagem</li><li>Educacional</li><li>Dotal (Misto e Puro)</li><li>Acidentes Pessoais</li><li>Vida</li><li>Perda do Certificado de Habilitação de Voo – PCHV</li><li>Doenças Graves ou Doença Terminal</li><li>Desemprego/ Perda de Renda</li><li>Eventos Aleatórios</li><li>Pecúlio</li><li>Pensão prazo certo</li><li>Pensão menores 21 anos</li><li>Pensão menores 24 anos</li><li>Pensão cônjuge vitalícia</li><li>Pensão cônjuge temporária</li></ol>;Texto;33;Obrigatório;;"FUNERAL 
 PRESTAMISTA 
 VIAGEM 
 EDUCACIONAL 
@@ -28,7 +34,7 @@ PENSAO_PRAZO_CERTO
 PENSAO_MENORES_21 
 PENSAO_MENORES_24 
 PENSAO_CONJUGE_VITALICIA 
-PENSAO_CONJUGE_TEMPORARIA";0;1;"";Não permitido;string;FUNERAL;
+PENSAO_CONJUGE_TEMPORARIA";1;1;"";Não permitido;string;FUNERAL;
 /data/coverages;coverages;;Lista;;Obrigatório;;;1;N;"";Não permitido;array;;
 /data/coverages/type;type;É o conjunto dos riscos cobertos elencados na apólice. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela Tipo de Cobertura ;Texto;62;Obrigatório;;"ADIANTAMENTO_DOENCA_ESTAGIO_TERMINAL 
 AUXILIO_CESTA_BASICA 
@@ -76,44 +82,42 @@ TRANSPLANTE_ORGAOS
 TRASLADO 
 TRANSLADO_CORPO 
 VERBA_RESCISORIA 
+DOENCA_GRAVE 
+TRANSLADO_MEDICO 
 OUTROS";1;1;"";Não permitido;string;INVALIDEZ_PERMANENTE_TOTAL_PARCIAL;
 /data/coverages/typeAdditionalInfos;typeAdditionalInfos;"Lista de textos para complementar informação relativa ao campo type, quando for selecionada a opção 'OUTROS'.
 Restrição: Campo de preenchimento obrigatório se 'type' estiver preenchida a opção 'OUTROS'
 ";Lista;100;Opcional;;;0;N;"";Não permitido;array;;
-/data/coverages/attributes;attributes;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
-/data/coverages/attributes/indemnityPaymentMethods;indemnityPaymentMethods;Listagem da forma de pagamento da indenização para cada combinação de modalidade/cobertura do produto.;Lista;42;Opcional;;"PAGAMENTO_CAPITAL_SEGURADO_VALOR_MONETARIO 
+/data/coverages/attributes;attributes;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
+/data/coverages/attributes/indemnityPaymentMethods;indemnityPaymentMethods;Listagem da forma de pagamento da indenização para cada combinação de modalidade/cobertura do produto.;Lista;42;Obrigatório;;"PAGAMENTO_CAPITAL_SEGURADO_VALOR_MONETARIO 
 REEMBOLSO_DESPESAS 
-PRESTACAO_SERVICOS";0;N;"";Não permitido;array;;
-/data/coverages/attributes/indemnityPaymentFrequencies;indemnityPaymentFrequencies;Listagem de tipos de frequência de pagamento de indenização para cada combinação de modalidade/cobertura do produto.;Lista;17;Opcional;;"INDENIZACAO_UNICA 
-DIARIA_OU_PARCELA";0;N;"";Não permitido;array;INDENIZACAO_UNICA;
+PRESTACAO_SERVICOS";1;N;"";Não permitido;array;;
+/data/coverages/attributes/indemnityPaymentFrequencies;indemnityPaymentFrequencies;Listagem de tipos de frequência de pagamento de indenização para cada combinação de modalidade/cobertura do produto.;Lista;17;Obrigatório;;"INDENIZACAO_UNICA 
+DIARIA_OU_PARCELA";1;N;"";Não permitido;array;INDENIZACAO_UNICA;
 /data/coverages/attributes/minValue;minValue;Listagem do valor mínimo de cobertura (Capital Segurado), diária ou parcela aceito pela sociedade para cada combinação de modalidade/cobertura do produto.<br>Conforme moeda.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/coverages/attributes/minValue/amount;amount;;Texto;21;Obrigatório;^\d{1,16}\.\d{2,4}$;;1;1;"";Não permitido;string;0.01;
 /data/coverages/attributes/minValue/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL;
 /data/coverages/attributes/maxValue;maxValue;Listagem do valor máximo de cobertura (Capital Segurado), diária ou parcela aceito pela sociedade para cada combinação de modalidade/cobertura do produto.<br>Conforme moeda.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/coverages/attributes/maxValue/amount;amount;;Texto;21;Obrigatório;^\d{1,16}\.\d{2,4}$;;1;1;"";Não permitido;string;0.01;
 /data/coverages/attributes/maxValue/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL;
-/data/coverages/attributes/indemnifiablePeriods;indemnifiablePeriods;;Lista;31;Opcional;;"QUANTIDADE_DETERMINADA_PARCELAS 
-FIM_CICLO_DETERMINADO";0;N;"";Não permitido;array;QUANTIDADE_DETERMINADA_PARCELAS;
-/data/coverages/attributes/maximumQtyIndemnifiableInstallments;maximumQtyIndemnifiableInstallments;Caso o período indenizável seja relacionado a parcelas, listagem de número máximo de parcelas indenizáveis para cada combinação de modalidade/ cobertura do produto.;Inteiro;10;Opcional;;;0;1;"";Não permitido;integer;10;
+/data/coverages/attributes/indemnifiablePeriods;indemnifiablePeriods;Listagem de período indenizável para cada combinação de modalidade/cobertura do produto.;Lista;50;Obrigatório;;;1;N;"";Não permitido;array;ATE_FIM_CICLO_DETERMINADO;
+/data/coverages/attributes/maximumQtyIndemnifiableInstallments;maximumQtyIndemnifiableInstallments;Caso o período indenizável seja relacionado a parcelas, listagem de número máximo de parcelas indenizáveis para cada combinação de modalidade/ cobertura do produto.;Inteiro;10;Obrigatório;;;1;1;"";Não permitido;integer;10;
 /data/coverages/attributes/gracePeriod;gracePeriod;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
-/data/coverages/attributes/gracePeriod/amount;amount;Informar o prazo de carência;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;90;
-/data/coverages/attributes/gracePeriod/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Obrigatório;;"DIAS 
+/data/coverages/attributes/gracePeriod/amount;amount;Informar o prazo de carência;Inteiro;;Opcional;;;0;1;"";Não permitido;integer;90;
+/data/coverages/attributes/gracePeriod/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Opcional;;"DIAS 
 MESES 
-NAO_APLICA";1;1;"";Não permitido;string;MESES;
-/data/coverages/attributes/differentiatedGracePeriod;differentiatedGracePeriod;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
-/data/coverages/attributes/differentiatedGracePeriod/amount;amount;Informar o prazo de carência;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;90;
-/data/coverages/attributes/differentiatedGracePeriod/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Obrigatório;;"DIAS 
-MESES 
-NAO_APLICA";1;1;"";Não permitido;string;MESES;
-/data/coverages/attributes/deductibleDays;deductibleDays;Listagem de franquia em dias para cada combinação de modalidade/cobertura do produto.;Inteiro;10;Opcional;;;0;1;"";Não permitido;integer;10;
+NAO_APLICA";0;1;"";Não permitido;string;MESES;
+/data/coverages/attributes/gracePeriod/details;details;;Texto;500;Opcional;[\w\W\s]*;;0;1;"";Não permitido;string;Descrições adicionais do período de carência;
+/data/coverages/attributes/differentiatedGracePeriod;differentiatedGracePeriod;Campo aberto para detalhamento de período de carência diferenciado, se houver.;Texto;500;Opcional;[\w\W\s]*;;0;1;"";Não permitido;string;90 DIAS;
+/data/coverages/attributes/deductibleDays;deductibleDays;Listagem de franquia em dias para cada combinação de modalidade/cobertura do produto.;Inteiro;10;Obrigatório;;;1;1;"";Não permitido;integer;10;
 /data/coverages/attributes/differentiatedDeductibleDays;differentiatedDeductibleDays;Detalhamento da franquia em dias diferentes para cada cobertura que exista alguma especificidade. Caso a seguradora não tenha essa diferenciação, não retornará nada no campo.;Inteiro;10;Opcional;;;0;1;"";Não permitido;integer;15;
-/data/coverages/attributes/deductible;deductible;Listagem de franquia em reais para cada combinação de modalidade/cobertura do produto.;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
+/data/coverages/attributes/deductible;deductible;Listagem de franquia em reais para cada combinação de modalidade/cobertura do produto.;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/coverages/attributes/deductible/amount;amount;;Texto;21;Obrigatório;^\d{1,16}\.\d{2,4}$;;1;1;"";Não permitido;string;0.01;
 /data/coverages/attributes/deductible/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL;
 /data/coverages/attributes/differentiatedDeductible;differentiatedDeductible;Detalhamento da franquia em reais diferentes para cada cobertura que exista alguma especificidade.<br>Caso a seguradora não tenha essa diferenciação, não retornará nada no campo.;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/coverages/attributes/differentiatedDeductible/amount;amount;;Texto;21;Obrigatório;^\d{1,16}\.\d{2,4}$;;1;1;"";Não permitido;string;0.01;
 /data/coverages/attributes/differentiatedDeductible/currency;currency;Moeda referente ao valor monetário, seguindo o modelo ISO-4217.;Texto;3;Obrigatório;^[A-Z]{3}$;;1;1;"";Não permitido;string;BRL;
-/data/coverages/attributes/excludedRisks;excludedRisks;;Lista;40;Opcional;;"ATO_RECONHECIMENTO_PERIGOSO 
+/data/coverages/attributes/excludedRisks;excludedRisks;;Lista;40;Obrigatório;;"ATO_RECONHECIMENTO_PERIGOSO 
 ATO_ILICITO_DOLOSO_PRATICADO_SEGURADO 
 OPERACOES_GUERRA 
 FURACOES_CICLONES_TERREMOTOS 
@@ -122,13 +126,13 @@ DOENCAS_LESOES_PREEXISTENTES
 EPIDEMIAS_PANDEMIAS 
 SUICIDIO 
 ATO_ILICITO_DOLOSO_PRATICADO_CONTROLADOR 
-OUTROS";0;N;"";Não permitido;array;ATO_RECONHECIMENTO_PERIGOSO;
+OUTROS";1;N;"";Não permitido;array;ATO_RECONHECIMENTO_PERIGOSO;
 /data/coverages/attributes/excludedRisksURL;excludedRisksURL;Campo aberto (possibilidade de incluir URL);Texto;1024;Opcional;;;0;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/coverages/attributes/allowApartPurchase;allowApartPurchase;"Indicar se a cobertura pode ser contratada isoladamente ou não:
   1. true
   2. false
-";Booleano;;Opcional;;;0;1;"";Não permitido;boolean;;
-/data/assistanceTypes;assistanceTypes;;Lista;43;Obrigatório;;"ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA 
+";Booleano;;Obrigatório;;;1;1;"";Não permitido;boolean;;
+/data/assistanceTypes;assistanceTypes;;Lista;43;Opcional;;"ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA 
 ARQUITETO_VIRTUAL 
 ASSESSORIA_FINANCEIRA 
 AUTOMOVEL 
@@ -183,7 +187,7 @@ SUSTENTAVEL_DESCARTE_ECOLOGICO
 TELEMEDICINA 
 VIAGEM 
 VITIMA 
-OUTROS";1;N;"";Não permitido;array;ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA;
+OUTROS";0;N;"";Não permitido;array;ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA;
 /data/assistanceTypesAdditionalInfos;assistanceTypesAdditionalInfos;Lista a ser preenchido pelas participantes quando houver ‘Outros’ no campo ‘Tipo de Assistência’;Lista;;Opcional;;;0;N;"";Não permitido;array;;
 /data/additionals;additionals;;Lista;44;Obrigatório;;"SORTEIO 
 SERVICOS_ASSISTENCIAS_COMPLEMENTARES_PAGO 
@@ -191,47 +195,47 @@ SERVICOS_ASSISTENCIA_COMPLEMENTARES_GRATUITO
 OUTROS 
 NAO_HA";1;N;"";Não permitido;array;SORTEIO;
 /data/termsAndConditions;termsAndConditions;;Lista;;Obrigatório;;;1;N;"";Não permitido;array;;
-/data/termsAndConditions/susepProcessNumber;susepProcessNumber;"Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.";Texto;20;Obrigatório;^\d{5}\.\d{6}/\d{4}-\d{2}$;;1;1;"";Não permitido;string;15414.622222/2222-22;
+/data/termsAndConditions/susepProcessNumber;susepProcessNumber;"Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.";Texto;20;Obrigatório;^\d{5}\.\d{6}\/\d{4}-\d{2}$|^\d{2}\.\d{6}\/\d{2}-\d{2}$|^\d{3}-\d{5}\/\d{2}$|^\d{5}\.\d{6}\/\d{2}-\d{2}$;;1;1;"";Não permitido;string;15414.622222/2222-22;12
 /data/termsAndConditions/detail;detail;Representam as Condições Gerais, Condições Especiais e Condições ou Cláusulas Particulares de um mesmo produto. (Circular SUSEP 321/06). Campo aberto (possibilidade de incluir URL);Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/globalCapital;globalCapital;"A considerar os seguintes domínios:
   1. true
   2. false
-";Booleano;;Opcional;;;0;1;"";Não permitido;boolean;true;
+";Booleano;;Obrigatório;;;1;1;"";Não permitido;boolean;true;
 /data/terms;terms;;Lista;23;Obrigatório;;"VITALICIA 
 TEMPORARIA_PRAZO_FIXO 
 TEMPORARIA_INTERMITENTE";1;N;"";Não permitido;array;VITALICIA;
 /data/pmbacRemuneration;pmbacRemuneration;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
-/data/pmbacRemuneration/interestRate;interestRate;Taxa de juros para capitalização da PMBaC;Texto;;Opcional;^\d{1,16}\.\d{4}$;;0;1;"";Não permitido;string;14.2521;
+/data/pmbacRemuneration/interestRate;interestRate;Taxa de juros para capitalização da PMBaC;Texto;8;Opcional;^\d{1}\.\d{6}$;;0;1;"";Não permitido;string;0.019800;8
 /data/pmbacRemuneration/updateIndexes;updateIndexes;;Lista;;Opcional;;"IPCA 
 IGP_M 
 INPC";0;N;"";Não permitido;array;IPCA;
-/data/benefitRecalculation;benefitRecalculation;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/benefitRecalculation;benefitRecalculation;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/benefitRecalculation/criterias;criterias;;Lista;;Obrigatório;;"INDICE 
 VINCULADO_SALDO_DEVEDOR 
 VARIAVEL_ACORDO_CRITERIO_ESPECIFICO";1;N;"";Não permitido;array;;
-/data/benefitRecalculation/updateIndexes;updateIndexes;;Lista;10;Obrigatório;;"IPCA 
+/data/benefitRecalculation/updateIndexes;updateIndexes;;Lista;;Opcional;;"IPCA 
 IGP_M 
-INPC 
-NAO_APLICA";1;N;"";Não permitido;array;IPCA;
+INPC";0;N;"";Não permitido;array;IPCA;
 /data/ageAdjustment;ageAdjustment;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/ageAdjustment/criterias;criterias;;Lista;27;Obrigatório;;"APOS_PERIODO_ANOS 
 CADA_PERIODO_ANOS 
 MUDANCA_FAIXA_ETARIA 
 NAO_APLICAVEL";1;N;"";Não permitido;array;APOS_PERIODO_ANOS;
 /data/ageAdjustment/frequency;frequency;Período em anos, caso critério de reenquadramento após ou a cada período em anos.;Inteiro;3;Obrigatório;;;1;1;"";Não permitido;integer;10;
-/data/financialRegimes;financialRegimes;;Lista;19;Opcional;;"REPARTICAO_SIMPLES 
+/data/financialRegimes;financialRegimes;;Lista;19;Obrigatório;;"REPARTICAO_SIMPLES 
 REPARTICAO_CAPITAIS 
-CAPITALIZACAO";0;N;"";Não permitido;array;REPARTICAO_SIMPLES;
+CAPITALIZACAO";1;N;"";Não permitido;array;REPARTICAO_SIMPLES;
 /data/reclaim;reclaim;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/reclaim/table;table;;Lista;;Opcional;;;1;N;"";Não permitido;array;;
-/data/reclaim/table/initialMonthRange;initialMonthRange;;Inteiro;2;Opcional;;;0;1;"";Não permitido;integer;1;
-/data/reclaim/table/finalMonthRange;finalMonthRange;;Inteiro;2;Opcional;;;0;1;"";Não permitido;integer;12;
-/data/reclaim/table/percentage;percentage;Percentual de faixa de resgate.;Texto;6;Opcional;^\d\.\d{4}$;;0;1;"";Não permitido;string;0.5000;
-/data/reclaim/gracePeriod;gracePeriod;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
+/data/reclaim/table/initialMonthRange;initialMonthRange;;Inteiro;2;Obrigatório;;;1;1;"";Não permitido;integer;1;
+/data/reclaim/table/finalMonthRange;finalMonthRange;;Inteiro;2;Obrigatório;;;1;1;"";Não permitido;integer;12;
+/data/reclaim/table/percentage;percentage;Percentual de faixa de resgate.;Texto;8;Obrigatório;^\d{1}\.\d{6}$;;1;1;"";Não permitido;string;0.019800;8
+/data/reclaim/gracePeriod;gracePeriod;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
 /data/reclaim/gracePeriod/amount;amount;Informar o prazo de carência;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;90;
 /data/reclaim/gracePeriod/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Obrigatório;;"DIAS 
 MESES 
 NAO_APLICA";1;1;"";Não permitido;string;MESES;
+/data/reclaim/gracePeriod/details;details;;Texto;500;Opcional;[\w\W\s]*;;0;1;"";Não permitido;string;Descrições adicionais do período de carência;
 /data/reclaim/differenciatedPercentage;differenciatedPercentage;Campo aberto (possibilidade de incluir URL);"";1024;Opcional;;;0;1;"";Não permitido;;"https://openinsurance.com.br/aaa’
 Obs.: Exceção de cobertura ou critério definido acima será descrito aqui na URL
 Exemplo: Cobertura X: a partir de 25 meses = 100%
@@ -241,7 +245,7 @@ BENEFICIO_PROLONGADO
 NAO_APLICA";0;N;"";Não permitido;array;SALDAMENTO;
 /data/allowPortability;allowPortability;"1. true
 2. false
-";Booleano;;Opcional;;;0;1;"";Não permitido;boolean;;
+";Booleano;;Obrigatório;;;1;1;"";Não permitido;boolean;;
 /data/portabilityGraceTime;portabilityGraceTime;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/portabilityGraceTime/amount;amount;Informar o prazo de carência;Inteiro;;Obrigatório;;;1;1;"";Não permitido;integer;90;
 /data/portabilityGraceTime/unit;unit;"Informar o critério de carência para a cobertura&#58;<br><ol><li>Dias</li><li>Meses</li><li>Não se aplica</li></ol>";Texto;10;Obrigatório;;"DIAS 
@@ -258,7 +262,7 @@ VITALICIA
 VITALICIA_REVERSIVEL 
 VITALICIA_MINIMO_GARANTIDO 
 VITALICIA_REVERSIVEL_MINIMO_GARANTIDO";0;N;"";Não permitido;array;CERTA;
-/data/premiumPayment;premiumPayment;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/premiumPayment;premiumPayment;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/premiumPayment/paymentMethods;paymentMethods;;Lista;27;Obrigatório;;"CARTAO_CREDITO 
 CARTAO_DEBITO 
 DEBITO_CONTA_CORRENTE 
@@ -266,8 +270,8 @@ DEBITO_CONTA_POUPANCA
 BOLETO_BANCARIO 
 PIX 
 CONSIGNACAO_FOLHA_PAGAMENTO 
-PONTOS_PROGRAMA_BENEFÍCIO 
-OUTROS";1;N;"";Não permitido;array;CARTAO_CREDITO;
+PONTOS_PROGRAMA_BENEFICIO 
+REGRA_PARCEIRO";1;N;"";Não permitido;array;CARTAO_CREDITO;
 /data/premiumPayment/frequencies;frequencies;;Lista;10;Obrigatório;;"DIARIA 
 MENSAL 
 UNICA 
@@ -277,15 +281,13 @@ SEMESTRAL
 FRACIONADO 
 OUTRA";1;N;"";Não permitido;array;DIARIA;
 /data/premiumPayment/contributionTax;contributionTax;Distribuição de frequência relativa aos valores referentes às taxas cobradas, nos termos do Anexo III.;Texto;500;Opcional;;;0;1;"";Não permitido;string;;
-/data/minimumRequirement;minimumRequirement;;Objeto;;Obrigatório;;;1;1;"";Não permitido;object;;
+/data/minimumRequirement;minimumRequirement;;Objeto;;Opcional;;;0;1;"";Não permitido;object;;
 /data/minimumRequirement/contractType;contractType;"A considerar os domínios abaixo:
   1. Coletivo;
   2. Individual
-  3. Ambas (Coletivo e Individual)
 ";Texto;10;Obrigatório;;"COLETIVO 
-INDIVIDUAL 
-AMBAS";1;1;"";Não permitido;string;COLETIVO;
-/data/minimumRequirement/contractingMinRequirement;contractingMinRequirement;Campo aberto (possibilidade de incluir URL);Texto;1024;Opcional;;;0;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
+INDIVIDUAL";1;1;"";Não permitido;string;COLETIVO;
+/data/minimumRequirement/contractingMinRequirement;contractingMinRequirement;Campo aberto (possibilidade de incluir URL);Texto;1024;Obrigatório;;;1;1;"";Não permitido;string;https://openinsurance.com.br/aaa;
 /data/targetAudience;targetAudience;"A considerar os domínios abaixo:
 
   1. Pessoa Natural

--- a/swagger-apis/insurances/1.0.0-rc2.0.yml
+++ b/swagger-apis/insurances/1.0.0-rc2.0.yml
@@ -20,52 +20,6 @@ tags:
   - name: Seguros
     description: 'Operações para consulta de informações de seguros automotivos, residenciais e pessoais'
 paths:
-  /automotives:
-    get:
-      tags:
-        - Seguros
-      summary: Conjunto de informações referentes a seguros automotivos de uma instituição
-      operationId: getAutomotiveInsurance
-      description: Método para obter a lista de todos os seguros automotivos de uma instituição
-      parameters:
-        - $ref: '#/components/parameters/page'
-        - $ref: '#/components/parameters/pageSize'
-      responses:
-        '200':
-          $ref: '#/components/responses/OKResponseAutomotiveInsuranceList'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '405':
-          $ref: '#/components/responses/MethodNotAllowed'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-  /homes:
-    get:
-      tags:
-        - Seguros
-      summary: Conjunto de informações referentes a seguros residenciais de uma instituição
-      operationId: getHomeInsurance
-      description: Método para obter a lista de todos os seguros automotivos de uma instituição
-      parameters:
-        - $ref: '#/components/parameters/page'
-        - $ref: '#/components/parameters/pageSize'
-      responses:
-        '200':
-          $ref: '#/components/responses/OKResponseHomeInsuranceList'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '405':
-          $ref: '#/components/responses/MethodNotAllowed'
-        '429':
-          $ref: '#/components/responses/TooManyRequests'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
   /personals:
     get:
       tags:
@@ -89,6 +43,8 @@ paths:
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '529':
+          $ref: '#/components/responses/SiteIsOverloaded'
 components:
   schemas:
     Participant:
@@ -113,6 +69,12 @@ components:
           $ref: '#/components/schemas/CnpjNumber'
         urlComplementaryList:
           type: string
+          description: |
+            Espera-se que valor de retorno, após acesso ao link 'urlComplementaryList', deve ser array de objeto com a estrutura abaixo:
+            - 'name' com o valor contido no campo 'LegalEntityName' conforme cadastro no diretório;
+            - 'cnpjNumber' com o valor contido no campo CNPJ ('RegistrationNumber') correspondente a esta instituição;
+            - Ambos do tipo string;
+            - Ambos obrigatórios. 
           maxLength: 1024
           pattern: '^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$'
           example: 'https://empresaa1.com/companies'
@@ -141,14 +103,35 @@ components:
       type: object
       properties:
         package:
-          $ref: '#/components/schemas/EnumAssistanceServicesPackageType'
+          type: string
+          description: |
+            1. Até 10 serviços
+            2. Até 20 serviços
+            3. Acima de 20 serviços
+            4. Customizável
+          maxLength: 17
+          enum:
+            - ATE_10_SERVICOS
+            - ATE_20_SERVICOS
+            - ACIMA_20_SERVICOS
+            - CUSTOMIZAVEL
+          example: ATE_10_SERVICOS
         detail:
           type: string
           description: Campo livre para descrição dos serviços ofertados por cada sociedade participante (incluindo indicação se o serviço é Gratuito ou Pago)
           maxLength: 1000
           example: Plano 1 - Cobertura de Assistência 24h com os serviços de - reboque pane seca - reboque pane mecanica - chaveiro - remoção médica - acompanhante hospital Inclui serviços residenciais gratuitos - Serviços à Residência
         chargeType:
-          $ref: '#/components/schemas/EnumChargeTypeSignalingType'
+          type: string
+          description: |
+            Sinalização em campo exclusivo se o pacote de Assistência é gratuita ou contratada/paga. A considerar os domínios abaixo:
+              1. Gratuita
+              2. Pago
+          maxLength: 8
+          enum:
+            - GRATUITA
+            - PAGO
+          example: GRATUITA
       additionalProperties: false
     CoverageItemAttributesMinLMI:
       type: object
@@ -215,9 +198,43 @@ components:
           type: array
           minItems: 1
           items:
-            $ref: '#/components/schemas/EnumPremiumPaymentMethodType'
+            type: string
+            description: |
+              Meio de pagamento escolhido pelo segurado. A considerar os domínios abaixo:
+                1. Cartão de Crédito
+                2. Cartão de Débito
+                3. Débito em conta corrente
+                4. Débito em conta poupança
+                5. Boleto bancário
+                6. PIX
+                7. Consignação em Folha de Pagamento
+                8. Pontos de Programa de Benefício
+                9. Outros
+            maxLength: 27
+            enum:
+              - CARTAO_CREDITO
+              - CARTAO_DEBITO
+              - DEBITO_CONTA_CORRENTE
+              - DEBITO_CONTA_POUPANCA
+              - BOLETO_BANCARIO
+              - PIX
+              - CONSIGNACAO_FOLHA_PAGAMENTO
+              - PONTOS_PROGRAMA_BENEFÍCIO
+              - OUTROS
+            example: CARTAO_CREDITO
         paymentType:
-          $ref: '#/components/schemas/EnumPremiumPaymentType'
+          type: string
+          description: |
+            Forma de pagamento:
+            1. A vista;
+            2. Parcelado;
+            3. Ambos
+          maxLength: 15
+          enum:
+            - A_VISTA
+            - PARCELADO
+            - AMBOS
+          example: A_VISTA
         paymentMethodsAdditionalInfo:
           type: string
           maxLength: 100
@@ -276,6 +293,11 @@ components:
           maximum: 9999999999
         unit:
           $ref: '#/components/schemas/EnumGracePeriodUnit'
+        details:
+          type: string
+          maxLength: 500
+          pattern: '[\w\W\s]*'
+          example: Descrições adicionais do período de carência
       additionalProperties: false
     TermsAndConditionsItem:
       type: object
@@ -286,8 +308,9 @@ components:
         susepProcessNumber:
           type: string
           description: 'Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais, conforme campo de consulta no site da SUSEP (XXXXX.XXXXXX/XXXX-XX)<br>Observação&#58; Mascaras da SUSEP – Serão permitidos todas as máscaras de Produtos. Limitar pelos códigos das Máscaras.'
+          minLength: 12
           maxLength: 20
-          pattern: '^\d{5}\.\d{6}/\d{4}-\d{2}$'
+          pattern: '^\d{5}\.\d{6}\/\d{4}-\d{2}$|^\d{2}\.\d{6}\/\d{2}-\d{2}$|^\d{3}-\d{5}\/\d{2}$|^\d{5}\.\d{6}\/\d{2}-\d{2}$'
           example: 15414.622222/2222-22
         detail:
           type: string
@@ -362,42 +385,15 @@ components:
       properties:
         interestRate:
           type: string
-          pattern: '^\d{1,16}\.\d{4}$'
+          pattern: '^\d{1}\.\d{6}$'
           description: Taxa de juros para capitalização da PMBaC
-          example: '14.2521'
+          maxLength: 8
+          minLength: 8
+          example: '0.019800'
         updateIndexes:
           type: array
           items:
-            $ref: '#/components/schemas/InsurancePensionBenefitRecalculation/properties/updateIndexes/items'
-      additionalProperties: false
-    InsurancePensionBenefitRecalculation:
-      type: object
-      required:
-        - criterias
-        - updateIndexes
-      properties:
-        criterias:
-          type: array
-          items:
-            type: string
-            enum:
-              - INDICE
-              - VINCULADO_SALDO_DEVEDOR
-              - VARIAVEL_ACORDO_CRITERIO_ESPECIFICO
-        updateIndexes:
-          type: array
-          items:
-            type: string
-            description: |
-              Índice utilizado na atualização da PMBaC:
-                1. IPCA (IBGE)
-                2. IGP-M (FGV)
-                3. INPC (IBGE)
-            enum:
-              - IPCA
-              - IGP_M
-              - INPC
-            example: IPCA
+            $ref: '#/components/schemas/EnumPersonalUpdateIndex'
       additionalProperties: false
     AgeAdjustment:
       type: object
@@ -441,42 +437,6 @@ components:
         - REPARTICAO_SIMPLES
         - REPARTICAO_CAPITAIS
         - CAPITALIZACAO
-    InsurancePensionReclaim:
-      type: object
-      properties:
-        table:
-          type: array
-          items:
-            $ref: '#/components/schemas/InsurancePensionReclaimTableItem'
-          minItems: 1
-        gracePeriod:
-          $ref: '#/components/schemas/GracePeriod'
-        differenciatedPercentage:
-          description: Campo aberto (possibilidade de incluir URL)
-          example: |
-            https://openinsurance.com.br/aaa’
-            Obs.: Exceção de cobertura ou critério definido acima será descrito aqui na URL
-            Exemplo: Cobertura X: a partir de 25 meses = 100%
-          maxLength: 1024
-      additionalProperties: false
-    InsurancePensionReclaimTableItem:
-      type: object
-      properties:
-        initialMonthRange:
-          type: integer
-          maxLength: 2
-          example: 1
-        finalMonthRange:
-          type: integer
-          maxLength: 2
-          example: 12
-        percentage:
-          type: string
-          pattern: '^\d\.\d{4}$'
-          description: Percentual de faixa de resgate.
-          maxLength: 6
-          example: '0.5000'
-      additionalProperties: false
     EnumPersonalIndemnifiablePeriodType:
       type: string
       description: |
@@ -489,854 +449,45 @@ components:
         - QUANTIDADE_DETERMINADA_PARCELAS
         - FIM_CICLO_DETERMINADO
       example: QUANTIDADE_DETERMINADA_PARCELAS
-    OKResponseAutomotiveInsuranceList:
-      type: object
-      required:
-        - data
-        - links
-        - meta
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/AutomotiveInsuranceData'
-        links:
-          $ref: '#/components/schemas/Links'
-        meta:
-          $ref: '#/components/schemas/OKResponseHomeInsuranceList/properties/meta'
-      additionalProperties: false
-    AutomotiveInsuranceData:
-      type: object
-      required:
-        - participant
-        - society
-        - name
-        - code
-        - coverages
-        - termsAndConditions
-        - terms
-        - minimumRequirement
-        - targetAudience
-      properties:
-        participant:
-          $ref: '#/components/schemas/Participant'
-        society:
-          $ref: '#/components/schemas/Society'
-        name:
-          type: string
-          description: 'Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.'
-          maxLength: 80
-          example: Produto A
-        code:
-          type: string
-          description: Código único a ser definido pela sociedade.
-          maxLength: 80
-          example: '0001'
-        coverages:
-          type: array
-          description: Coberturas
-          items:
-            $ref: '#/components/schemas/AutomotiveCoverageItem'
-          minItems: 1
-        carParts:
-          type: array
-          description: Tipo de peça utilizada para reparação – Nova ou Usada.
-          items:
-            $ref: '#/components/schemas/AutomotivePartsItem'
-          minItems: 1
-        carModel:
-          $ref: '#/components/schemas/AutomotiveModel'
-        vehicleOvernightPostalCode:
-          type: number
-          description: 'O conjunto de dados de Produtos que vai retornar está condicionado ao input do valor de CEP (Filtro). Nesse contexto será necessário que o CEP de consulta seja inserido. Código de Endereçamento Postal: Composto por um conjunto numérico de oito dígitos, o objetivo principal do CEP é orientar e acelerar o encaminhamento, o tratamento e a entrega de objetos postados nos Correios, por meio da sua atribuição a localidades, logradouros, unidades dos Correios, serviços, órgãos públicos, empresas e edifícios. p.ex. ''01311000'''
-          maxLength: 8
-          example: 1311000
-        additionals:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumInsuranceAdditionalType'
-        additionalInfo:
-          type: string
-          description: Campo aberto para descrição de cada participante ao selecionar o domínio ‘Outros’ no campo acima ‘Adicionais’ diferenciais do produto em questão.
-          maxLength: 100
-          example: 'Detalhar os serviços, benefícios e outros'
-        assistanceServices:
-          type: array
-          description: Serviços de Assistência
-          items:
-            $ref: '#/components/schemas/AssistanceServicesItem'
-          minItems: 1
-        termsAndConditions:
-          type: array
-          items:
-            $ref: '#/components/schemas/TermsAndConditionsItem'
-          minItems: 1
-        terms:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumInsuranceTermType'
-        termsAdditionalInfo:
-          type: string
-          description: 'Texto livre para complementar informação relativa ao campo terms, quando for selecionada a opção ''Outros'''
-          maxLength: 255
-        customerService:
-          $ref: '#/components/schemas/EnumCustomerServiceType'
-        premiumPayment:
-          $ref: '#/components/schemas/PremiumPayment'
-        minimumRequirement:
-          $ref: '#/components/schemas/InsuranceMinimumRequirement'
-        targetAudience:
-          $ref: '#/components/schemas/EnumTargetAudience'
-      additionalProperties: false
-    AutomotiveInsuranceDeterminedValue:
-      type: object
-      required:
-        - min
-        - max
-      properties:
-        min:
-          $ref: '#/components/schemas/ContractBaseDeterminedValue'
-        max:
-          $ref: '#/components/schemas/ContractBaseDeterminedValue'
-      additionalProperties: false
-    AutomotiveInsuranceMarketValuePercentage:
-      type: object
-      required:
-        - min
-        - max
-      properties:
-        min:
-          type: string
-          pattern: '^\d\.\d{2}$'
-          example: '0.20'
-        max:
-          type: string
-          pattern: '^\d\.\d{2}$'
-          example: '1.00'
-      additionalProperties: false
-    AutomotiveCoverageItem:
-      type: object
-      required:
-        - type
-        - attributes
-      properties:
-        type:
-          $ref: '#/components/schemas/EnumAutomotiveCoverageType'
-        detail:
-          type: string
-          description: 'Campo aberto para detalhamento de cada uma das coberturas possíveis dos produtos a ser feito por cada participante, conforme domínios da lista padronizada de coberturas (macro).'
-          maxLength: 1000
-          example: NA
-        permissionSeparateAcquisition:
-          type: boolean
-          description: |
-            Indicação se a cobertura permite contratação separada (por cobertura selecionada) conforme domínios abaixo:
-             1. true
-             2. false
-          example: true
-        attributes:
-          $ref: '#/components/schemas/AutomotiveCoverageItemAttributes'
-      additionalProperties: false
-    EnumAutomotiveCoverageType:
+    EnumInsurancePersonalBenefitRecalculationUpdateIndex:
       type: string
-      description: 'É o conjunto dos riscos cobertos elencados na apólice. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela Tipo de Cobertura'
-      maxLength: 75
+      description: |
+        Índice utilizado na atualização do prêmio/contribuição e do capital segurado/ benefício, caso critério de atualização por meio de índice
       enum:
-        - ROUBO_TOTAL_OU_PARCIAL
-        - FURTO_TOTAL_OU_PARCIAL
-        - ABALROAMENTO
-        - DESPESAS_NECESSARIAS_SOCORRO_SALVAMENTO
-        - DESPESAS_HIGIENIZACAO_VEÍCULO
-        - DESPESAS_EXTRAORDINARIAS
-        - DESPESAS_EXTRAORDINARIAS_MOTO
-        - DESPESAS_MEDICO_HOSPITALARES
-        - DESPESAS_ODONTOLOGICAS
-        - CREDITOS_CORRIDAS_APLICATIVOS_TRANSPORTE
-        - COBERTURA_ADICIONAL_OPCIONAIS
-        - DESPESAS_EXTRAS_INDENIZACAO_INTEGRAL
-        - DESPESAS_EXTRAS_INDENIZACAO_PARCIAL
-        - SEGURO_GARANTIDO_CASO_INDENIZACAO_INTEGRAL
-        - REPARO_RAPIDO_SUPERMARTELINHO
-        - ISENCAO_FRANQUIA
-        - DESCONTO_FRANQUIA
-        - COBERTURA_VEICULO_REBOCADO
-        - DANOS_CORPORAIS_RCFV
-        - DANOS_MATERIAIS_RCFV
-        - DANOS_MORAIS_RCFV
-        - DANOS_ESTETICOS_RCFV
-        - EXTENSAO_COBERTURA_DANOS_CORPORAIS_RCFV
-        - DANOS_CORPORAIS_RCFC
-        - DANOS_MATERIAIS_RCFC
-        - DANOS_MORAIS_RCFC
-        - DANOS_ESTETICOS_RCFC
-        - CARTA_VERDE_DANOS_CORPORAIS
-        - CARTA_VERDE_DANOS_MATERIAIS
-        - APP_DMHO_PASSAGEIRO
-        - APP_INVALIDEZ_PERMANENTE_PASSAGEIRO
-        - APP_MORTE_PASSAGEIRO
-        - APP_INVALIDEZ_PERMANENTE_TOTAL_PARCIAL
-        - VIDROS
-        - RETROVISORES
-        - FAROIS
-        - LANTERNAS
-        - DESPESAS_LOCACAO
-        - ROUBO_FURTO_RADIO
-        - ROUBO_FURTO_CD
-        - ROUBO_FURTO_KIT_GAS
-        - ROUBO_FURTO_TACOGRAFO
-        - TAXIMETRO
-        - LUMINOSO
-        - CARROCERIA
-        - EQUIPAMENTOS_ESPECIAIS_OPCIONAIS
-        - ACESSORIOS
-        - BLINDAGEM
-        - COBERTURA_BENS_DEIXADOS_INTERIOR_VEICULO
-        - COBERTURA_VEICULOS_ADAPTADOS_DEFICIENTES_FISICOS
-        - EIXO_ADICIONAL
-        - EQUIPAMENTOS
-        - REPARO_AIR_BAG_REPOSICAO
-        - COBERTURA_PARA_CHOQUE
-        - ENVELOPAMENTO
-        - DIARIA_INDISPONIBILIDADE
-        - MOTOR_TRANSMISSÃO
-        - MOTOR_TRANSMISSAO_DIRECAO_SUSPENSAO_FREIOS
-        - MOTOR_TRANSMISSAO_DIRECAO_SUSPENSAO_FREIOS_SISTEMA_ELETRICO_AR_CONDICIONADO
-        - COMPLETA
-        - CONFORTO
-        - SIMPLES
-        - GARANTIA_FRANQUIA_AUTOMOVEL
-        - OUTRAS_COBERTURAS_AUTO
-      example: ROUBO_TOTAL_OU_PARCIAL
-    AutomotiveCoverageItemAttributes:
+        - IPCA
+        - IGP_M
+        - INPC
+      example: IPCA
+    EnumPersonalUpdateIndex:
+      type: string
+      description: |
+        Índice utilizado na atualização da PMBaC:
+          1. IPCA (IBGE)
+          2. IGP-M (FGV)
+          3. INPC (IBGE)
+      enum:
+        - IPCA
+        - IGP_M
+        - INPC
+      example: IPCA
+    OpenDataMeta:
       type: object
-      description: Atributos da cobertura
+      description: Meta informações referente à API requisitada.
       required:
-        - deductibleTypes
-        - fullIndemnityDeductible
+        - totalRecords
+        - totalPages
       properties:
-        minLMI:
-          $ref: '#/components/schemas/CoverageItemAttributesMinLMI'
-        maxLMI:
-          $ref: '#/components/schemas/CoverageItemAttributesMaxLMI'
-        newCar:
-          $ref: '#/components/schemas/NewCar'
-        fullIndemnityPercentage:
-          type: string
-          description: 'Será caracterizada a indenização integral quando os prejuízos resultantes de um mesmo sinistro, atingirem ou ultrapassarem a quantia apurada a partir da aplicação de percentual previamente determinado sobre o valor contratado. (Circular 269/2004).'
-          pattern: '^\d\.\d{2}$'
-          maxLength: 4
-          example: '0.75'
-        deductibleTypes:
-          description: Listagem de tipo de franquia para cada tipo de cobertura do produto.
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumCoverageItemDeductibleType'
-        fullIndemnityDeductible:
-          type: boolean
-          description: |
-            (Circular 269/2004). A considerar os domínios abaixo:
-            1. true
-            2. false
-          example: true
-        deductiblePaymentByCoverage:
-          type: boolean
-          description: |
-            Mudança do campo com a sinalização para cada cobertura se a seguradora exige pagamento de franquia.
-             1. true
-             2. false
-          example: true
-        deductiblePercentage:
-          type: string
-          pattern: '^\d\.\d{2}$'
-          description: Percentual de Franquia
-          maxLength: 4
-          example: '0.75'
-        mandatoryParticipation:
-          type: string
-          maxLength: 300
-          example: |
-            Casco: R$ 0,00
-            RCF-V Danos
-            Materiais: X%
-          description: |
-            Participação Obrigatória é o valor ou percentual definido na apólice referente à responsabilidade do Segurado nos prejuízos indenizáveis decorrentes de sinistros cobertos.
-            (Circular SUSEP 347/07). Listagem de percentual de Franquia/Percentual Participação Obrigatória do Segurado estabelecida pela sociedade para cada tipo de cobertura do  produto.
-        geographicScope:
-          $ref: '#/components/schemas/AutomotiveGeoGraphicScope'
-        contractBase:
-          $ref: '#/components/schemas/ContractBase'
-      additionalProperties: false
-    ContractBase:
-      description: Base de contratação
-      type: object
-      properties:
-        determinedValue:
-          $ref: '#/components/schemas/AutomotiveInsuranceDeterminedValue'
-        marketValuePercentage:
-          $ref: '#/components/schemas/AutomotiveInsuranceMarketValuePercentage'
-      additionalProperties: false
-    NewCar:
-      type: object
-      properties:
-        contractBase:
-          $ref: '#/components/schemas/ContractBase'
-        maximumCalculatingPeriod:
+        totalRecords:
           type: integer
-          description: Prazo máximo para veículo zero quilômetro em meses
-          maxLength: 3
-          example: 12
+          format: int32
+          description: Número total de registros no resultado
+          example: 1
+        totalPages:
+          type: integer
+          format: int32
+          description: Número total de páginas no resultado
+          example: 1
       additionalProperties: false
-    AutomotiveGeoGraphicScope:
-      type: object
-      properties:
-        coverages:
-          type: array
-          minItems: 1
-          items:
-            $ref: '#/components/schemas/EnumCoverageItemGeographicScopeType'
-        details:
-          type: string
-          description: Detalhamento das regiões e países de abrangência.
-          example: |
-            Brasil, Argentina,
-            Uruguai, Paraguai,
-            Chile, Bolívia e
-            Venezuela
-          maxLength: 255
-      additionalProperties: false
-    ContractBaseDeterminedValue:
-      type: object
-      required:
-        - amount
-        - unit
-      properties:
-        amount:
-          type: string
-          pattern: '^\d{1,16}\.\d{2,4}$'
-          description: |
-            Valor Determinado - Valor Mínimo (R$).Observação: Campo condicional quando houver a seleção do domínio ‘Valor Determinado’ no campo ‘Base de Contratação’
-          maxLength: 21
-          example: '50.000'
-        currency:
-          $ref: '#/components/schemas/CurrencyCode'
-      additionalProperties: false
-    EnumCoverageItemDeductibleType:
-      type: string
-      description: |
-        Listagem de tipo de franquia para cada tipo de cobertura do produto, a considerar os domínios abaixo:
-          1. Normal;
-          2. Reduzida.
-          3. Isenta
-          4. Majorada
-          5. Flexível
-      maxLength: 10
-      enum:
-        - NORMAL
-        - REDUZIDA
-        - ISENTA
-        - MAJORADA
-        - FLEXIVEL
-      example: NORMAL
-    EnumCoverageItemGeographicScopeType:
-      type: string
-      description: |
-        Listagem de abrangência geográfica do produto para fins de cada cobertura:
-          1. Nacional
-          2. Regional
-          3. Internacional
-          4. Apenas outros países
-
-        Observação: o campo permite a seleção de mais de um item (multivalorado)
-      maxLength: 13
-      enum:
-        - NACIONAL
-        - REGIONAL
-        - INTERNACIONAL
-        - OUTROS_PAISES
-      example: NACIONAL
-    AutomotivePartsItem:
-      type: object
-      properties:
-        condition:
-          type: string
-          description: |
-            Novas ou usada. A considerar os domínios abaixo:
-              1. Novas
-              2. Usadas
-              3. Ambas
-          enum:
-            - NOVAS
-            - USADAS
-            - AMBAS
-          example: NOVAS
-        type:
-          $ref: '#/components/schemas/EnumAutomotivePartType'
-      additionalProperties: false
-    EnumAutomotivePartType:
-      type: string
-      description: |
-        Originais e Compatíveis. A considerar os domínios abaixo:
-          1. Originais
-          2. Compatíveis
-          3. Ambas
-      maxLength: 11
-      enum:
-        - ORIGINAIS
-        - COMPATIVEIS
-        - AMBAS
-      example: ORIGINAIS
-    AutomotiveModel:
-      type: object
-      properties:
-        model:
-          type: string
-          description: Chamada via código FIPE – retorna os veículos (Modelo) que são cobertos no produto
-          maxLength: 20
-          example: KA
-          minItems: 1
-        year:
-          type: number
-          format: integer
-          description: Chamada via código FIPE – retorna os veículos (Ano) que são cobertos no produto
-          maximum: 9999
-          example: 1985
-        manufacturer:
-          type: string
-          description: Chamada via código FIPE – retorna os veículos (Marca) que são cobertos no produto
-          maxLength: 20
-          example: FORD
-        fipeCode:
-          type: string
-          description: Chamada via código FIPE – retorna os veículos (código fipe) que são cobertos no produto
-          maxLength: 20
-          example: 003128-3
-      additionalProperties: false
-    EnumInsuranceAdditionalType:
-      type: string
-      description: |
-        A considerar os seguintes domínios abaixo:
-          1. Sorteio Gratuito
-          2. Clube de Benefícios
-          3. Cashback
-          4. Descontos
-          5. Outros
-      maxLength: 16
-      enum:
-        - SORTEIO_GRATUITO
-        - CLUBE_BENEFICIOS
-        - CASHBACK
-        - DESCONTOS
-        - OUTROS
-      example: SORTEIO_GRATUITO
-    EnumAssistanceServicesPackageType:
-      type: string
-      description: |
-        1. Até 10 serviços
-        2. Até 20 serviços
-        3. Acima de 20 serviços
-        4. Customizável
-      maxLength: 17
-      enum:
-        - ATE_10_SERVICOS
-        - ATE_20_SERVICOS
-        - ACIMA_20_SERVICOS
-        - CUSTOMIZAVEL
-      example: ATE_10_SERVICOS
-    EnumChargeTypeSignalingType:
-      type: string
-      description: |
-        Sinalização em campo exclusivo se o pacote de Assistência é gratuita ou contratada/paga. A considerar os domínios abaixo:
-          1. Gratuita
-          2. Pago
-      maxLength: 8
-      enum:
-        - GRATUITA
-        - PAGO
-      example: GRATUITA
-    EnumInsuranceTermType:
-      type: string
-      description: |
-        1.  anual
-        2.  anual intermitente
-        3.  plurianual
-        4.  plurianual intermitente
-        5.  semestral
-        6.  semestral intermitente
-        7.  mensal
-        8.  mensal intermitente
-        9.  diário
-        10. diário intermitente
-        11. Outros
-      maxLength: 23
-      enum:
-        - ANUAL
-        - ANUAL_INTERMITENTE
-        - PLURIANUAL
-        - PLURIANUAL_INTERMITENTE
-        - SEMESTRAL
-        - SEMESTRAL_INTERMITENTE
-        - MENSAL
-        - MENSAL_INTERMITENTE
-        - DIARIO
-        - DIARIO_INTERMITENTE
-        - OUTROS
-      example: ANUAL
-    EnumCustomerServiceType:
-      type: string
-      description: |
-        Rede de atendimento do seguro contratado. A considerar os domínios abaixo:
-          1. Rede Referenciada
-          2. Livre Escolha
-          3. Rede Referenciada e Livre Escolha
-      maxLength: 31
-      enum:
-        - REDE_REFERENCIADA
-        - LIVRE_ESCOLHA
-        - REDE_REFERENCIADA_LIVRE_ESCOLHA
-      example: REDE_REFERENCIADA
-    EnumPremiumPaymentMethodType:
-      type: string
-      description: |
-        Meio de pagamento escolhido pelo segurado. A considerar os domínios abaixo:
-          1. Cartão de Crédito
-          2. Cartão de Débito
-          3. Débito em conta corrente
-          4. Débito em conta poupança
-          5. Boleto bancário
-          6. PIX
-          7. Consignação em Folha de Pagamento
-          8. Pontos de Programa de Benefício
-          9. Outros
-      maxLength: 27
-      enum:
-        - CARTAO_CREDITO
-        - CARTAO_DEBITO
-        - DEBITO_CONTA_CORRENTE
-        - DEBITO_CONTA_POUPANCA
-        - BOLETO_BANCARIO
-        - PIX
-        - CONSIGNACAO_FOLHA_PAGAMENTO
-        - PONTOS_PROGRAMA_BENEFÍCIO
-        - OUTROS
-      example: CARTAO_CREDITO
-    EnumPremiumPaymentType:
-      type: string
-      description: |
-        Forma de pagamento:
-        1. A vista;
-        2. Parcelado;
-        3. Ambos
-      maxLength: 15
-      enum:
-        - A_VISTA
-        - PARCELADO
-        - AMBOS
-      example: A_VISTA
-    EnumTargetAudience:
-      type: string
-      description: |
-        A considerar os domínios abaixo:
-
-          1. Pessoa Natural
-          2. Pessoa Jurídica
-          3. Ambas (Pessoa Natural e Jurídica)
-      maxLength: 23
-      enum:
-        - PESSOA_NATURAL
-        - PESSOA_JURIDICA
-        - PESSOA_NATURAL_JURIDICA
-      example: PESSOA_NATURAL
-    OKResponseHomeInsuranceList:
-      type: object
-      required:
-        - data
-        - links
-        - meta
-      properties:
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/HomeInsuranceData'
-        links:
-          $ref: '#/components/schemas/Links'
-        meta:
-          type: object
-          description: Meta informações referente à API requisitada.
-          required:
-            - totalRecords
-            - totalPages
-          properties:
-            totalRecords:
-              type: integer
-              format: int32
-              description: Número total de registros no resultado
-              example: 1
-            totalPages:
-              type: integer
-              format: int32
-              description: Número total de páginas no resultado
-              example: 1
-          additionalProperties: false
-      additionalProperties: false
-    HomeInsuranceData:
-      type: object
-      required:
-        - participant
-        - society
-        - name
-        - code
-        - coverages
-        - propertyCharacteristics
-        - termsAndConditions
-        - terms
-        - minimumRequirement
-        - targetAudience
-      properties:
-        participant:
-          $ref: '#/components/schemas/Participant'
-        society:
-          $ref: '#/components/schemas/Society'
-        name:
-          type: string
-          description: 'Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.'
-          maxLength: 80
-          example: Produto A
-        code:
-          type: string
-          description: Código único a ser definido pela sociedade.
-          maxLength: 80
-          example: '0001'
-        coverages:
-          type: array
-          items:
-            $ref: '#/components/schemas/HomeCoverageItem'
-          minItems: 1
-        propertyCharacteristics:
-          type: array
-          items:
-            $ref: '#/components/schemas/HomePropertyCharacteristics'
-          minItems: 1
-        propertyPostalCode:
-          pattern: '^\d{8}$'
-          type: string
-          description: 'O conjunto de dados de Produtos que vai retornar está condicionado ao input do valor de CEP (Filtro). Nesse contexto será necessário que o CEP de consulta seja inserido. Código de Endereçamento Postal: Composto por um conjunto numérico de oito dígitos, o objetivo principal do CEP é orientar e acelerar o encaminhamento, o tratamento e a entrega de objetos postados nos Correios, por meio da sua atribuição a localidades, logradouros, unidades dos Correios, serviços, órgãos públicos, empresas e edifícios. p.ex. ''01311000'''
-          maxLength: 8
-          example: '13110000'
-        protective:
-          type: boolean
-          description: |
-            Indicativo de exigência de itens protecionais (por exemplo, alarmes) a considerar os seguintes domínios abaixo:
-              1. true
-              2. false
-          example: false
-        additionals:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumInsuranceAdditionalType'
-          example:
-            - SORTEIO_GRATUITO
-        additionalInfo:
-          type: string
-          description: 'Texto livre para complementar informação relativa ao additional, quando for selecionada a opção ''Outros'''
-          maxLength: 100
-          example: 'Detalhar os serviços, benefícios e outros'
-        assistanceServices:
-          type: array
-          items:
-            $ref: '#/components/schemas/AssistanceServicesItem'
-          minItems: 1
-        termsAndConditions:
-          type: array
-          items:
-            $ref: '#/components/schemas/TermsAndConditionsItem'
-          minItems: 1
-        terms:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumInsuranceTermType'
-        termsAdditionalInfo:
-          type: string
-          description: 'Texto livre para complementar informação relativa ao campo terms, quando for selecionada a opção ''Outros'''
-          maxLength: 255
-        customerService:
-          $ref: '#/components/schemas/EnumCustomerServiceType'
-        premiumPayment:
-          $ref: '#/components/schemas/PremiumPayment'
-        minimumRequirement:
-          $ref: '#/components/schemas/InsuranceMinimumRequirement'
-        targetAudience:
-          $ref: '#/components/schemas/EnumTargetAudience'
-      additionalProperties: false
-    HomeCoverageItem:
-      type: object
-      required:
-        - type
-      properties:
-        type:
-          $ref: '#/components/schemas/EnumHomeCoverageType'
-        detail:
-          type: string
-          description: 'Campo aberto para detalhamento de cada uma das coberturas possíveis dos produtos a ser feito por cada participante, conforme domínios da lista padronizada de coberturas (macro).'
-          maxLength: 1000
-        permissionSeparateAcquisition:
-          type: boolean
-          description: |
-            Indicação se a cobertura permite contratação separada (por cobertura selecionada) conforme domínios abaixo:
-              1. true
-              2. false
-          example: true
-        attributes:
-          $ref: '#/components/schemas/HomeCoverageItemAttributes'
-      additionalProperties: false
-    HomeMinDeductibleAmount:
-      type: object
-      description: 'Quantia fixa, definida na apólice, que, em caso de sinistro, representa a parte do prejuízo apurado que poderá deixar de ser paga pela Sociedade Seguradora, dependendo das disposições do contrato. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de valor mínimo da franquia (Reais) estabelecida pela sociedade para cada tipo de cobertura do produto.'
-      required:
-        - amount
-        - currency
-      properties:
-        amount:
-          type: string
-          pattern: '^\d{1,16}\.\d{2,4}$'
-          example: '1.1000'
-        currency:
-          $ref: '#/components/schemas/CurrencyCode'
-      additionalProperties: false
-    EnumHomeCoverageType:
-      type: string
-      description: 'É o conjunto dos riscos cobertos elencados na apólice. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela Tipo de Cobertura'
-      maxLength: 40
-      enum:
-        - IMOVEL_BASICA
-        - IMOVEL_AMPLA
-        - DANOS_ELETRICOS
-        - DANOS_AGUA
-        - ALAGAMENTO
-        - RESPONSABILIDADE_CIVIL_FAMILIAR
-        - RESPONSABILIDADE_CIVIL_DANOS_MORAIS
-        - ROUBO_SUBTRACAO_BENS
-        - ROUBO_SUBTRACAO_BENS_FORA_LOCAL_SEGURADO
-        - TACOS_GOLFE_HOLE_ONE
-        - PEQUENAS_REFORMAS_OBRAS
-        - GRAVES_TUMULTOS_LOCKOUT
-        - MICROEMPREENDEDOR
-        - ESCRITORIO_RESIDENCIA
-        - DANOS_EQUIPAMENTOS_ELETRONICOS
-        - QUEBRA_VIDROS
-        - IMPACTO_VEICULOS
-        - VENDAVAL
-        - PERDA_PAGAMENTO_ALUGUEL
-        - BICICLETA
-        - RESPONSABILIDADE_CIVIL_BICICLETA
-        - RC_EMPREGADOR
-        - DESMORONAMENTO
-        - DESPESAS
-        - JOIAS_OBRAS_ARTE
-        - TERREMOTO
-        - IMPACTO_AERONAVES
-        - PAISAGISMO
-        - INCENDIO
-        - QUEDA_RAIO
-        - EXPLOSAO
-        - OUTROS
-      example: IMOVEL_BASICA
-    HomeCoverageItemAttributes:
-      type: object
-      properties:
-        minLMI:
-          $ref: '#/components/schemas/CoverageItemAttributesMinLMI'
-        maxLMI:
-          $ref: '#/components/schemas/CoverageItemAttributesMaxLMI'
-        minDeductibleAmount:
-          $ref: '#/components/schemas/HomeMinDeductibleAmount'
-        insuredMandatoryParticipationPercentage:
-          type: string
-          pattern: '^\d\.\d{6}$'
-          description: 'Participação Obrigatória é o valor ou percentual definido na apólice referente à responsabilidade do Segurado nos prejuízos indenizáveis decorrentes de sinistros cobertos. (Circular SUSEP 347/07). Listagem de percentual de franquia e/ou Percentual Participação Obrigatória do Segurado estabelecida pela sociedade para cada tipo de cobertura do produto. Observação: Sugestão de Criação do campo em substituição ao campo abaixo ‘Valor Máximo de Franquia’.'
-          maxLength: 8
-          example: '0.000002'
-      additionalProperties: false
-    HomePropertyCharacteristics:
-      type: object
-      required:
-        - type
-        - buildTypes
-        - usageTypes
-        - importanceInsureds
-      properties:
-        type:
-          $ref: '#/components/schemas/EnumHomePropertyType'
-        buildTypes:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumHomePropertyBuildType'
-        usageTypes:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumHomePropertyUsageType'
-          example:
-            - HABITUAL
-        importanceInsureds:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnumHomeImportanceInsuredType'
-          example:
-            - PREDIO
-      additionalProperties: false
-    EnumHomePropertyType:
-      type: string
-      description: |
-        Proposta conforme os domínios abaixo:
-          1. Casa
-          2. Apartamento
-      maxLength: 11
-      enum:
-        - CASA
-        - APARTAMENTO
-      example: CASA
-    EnumHomePropertyBuildType:
-      type: string
-      description: |
-        A considerar os seguintes domínios abaixo:
-          1. Alvenaria
-          2. Madeira
-          3. Mista (Alvenaria e Madeira)
-      maxLength: 9
-      enum:
-        - ALVENARIA
-        - MADEIRA
-        - MISTA
-      example: ALVENARIA
-    EnumHomePropertyUsageType:
-      type: string
-      description: |
-        A considerar os seguintes domínios abaixo:
-          1. Habitual
-          2. Veraneio
-          3. Desocupado
-          4. Casa/Escritório
-          5. Aluguel por temporada
-      maxLength: 17
-      enum:
-        - HABITUAL
-        - VERANEIO
-        - DESOCUPADO
-        - CASA_ESCRITORIO
-        - ALUGUEL_TEMPORADA
-      example: HABITUAL
-    EnumHomeImportanceInsuredType:
-      type: string
-      description: |
-        A considerar os seguintes domínios abaixo:
-          1. Prédio
-          2. Conteúdo
-          3. Ambos
-      maxLength: 8
-      enum:
-        - PREDIO
-        - CONTEUDO
-        - AMBOS
-      example: PREDIO
     OKResponsePersonalInsuranceList:
       type: object
       required:
@@ -1351,7 +502,7 @@ components:
         links:
           $ref: '#/components/schemas/Links'
         meta:
-          $ref: '#/components/schemas/OKResponseHomeInsuranceList/properties/meta'
+          $ref: '#/components/schemas/OpenDataMeta'
       additionalProperties: false
     PersonalInsuranceData:
       type: object
@@ -1360,21 +511,21 @@ components:
         - society
         - name
         - code
+        - modality
         - coverages
-        - assistanceTypes
         - additionals
         - termsAndConditions
+        - globalCapital
         - terms
-        - benefitRecalculation
+        - financialRegimes
+        - allowPortability
         - indemnityPaymentMethods
-        - premiumPayment
-        - minimumRequirement
         - targetAudience
       properties:
         participant:
           $ref: '#/components/schemas/Participant'
         society:
-          $ref: '#/components/schemas/Society'
+          $ref: '#/components/schemas/PersonalInsuranceSociety'
         name:
           type: string
           description: 'Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.'
@@ -1509,33 +660,7 @@ components:
         pmbacRemuneration:
           $ref: '#/components/schemas/InsurancePensionEnumPmbacRemuneration'
         benefitRecalculation:
-          type: object
-          required:
-            - criterias
-            - updateIndexes
-          properties:
-            criterias:
-              type: array
-              items:
-                $ref: '#/components/schemas/InsurancePensionBenefitRecalculation/properties/criterias/items'
-            updateIndexes:
-              type: array
-              items:
-                type: string
-                description: |
-                  Índice utilizado na atualização da PMBaC:
-                    1. IPCA (IBGE)
-                    2. IGP-M (FGV)
-                    3. INPC (IBGE)
-                    4. NÃO APLICA
-                maxLength: 10
-                enum:
-                  - IPCA
-                  - IGP_M
-                  - INPC
-                  - NAO_APLICA
-                example: IPCA
-          additionalProperties: false
+          $ref: '#/components/schemas/BenefitRecalculation'
         ageAdjustment:
           $ref: '#/components/schemas/AgeAdjustment'
         financialRegimes:
@@ -1543,7 +668,7 @@ components:
           items:
             $ref: '#/components/schemas/InsurancePensionEnumFinancialRegime'
         reclaim:
-          $ref: '#/components/schemas/InsurancePensionReclaim'
+          $ref: '#/components/schemas/PersonalInsuranceReclaim'
         otherGuaranteedValues:
           type: array
           items:
@@ -1554,7 +679,7 @@ components:
             1. true
             2. false
         portabilityGraceTime:
-          $ref: '#/components/schemas/GracePeriod'
+          $ref: '#/components/schemas/PersonalInsurancePortabilityGraceTime'
         indemnityPaymentMethods:
           type: array
           items:
@@ -1566,69 +691,29 @@ components:
         premiumPayment:
           $ref: '#/components/schemas/PersonalInsurancePremiumPayment'
         minimumRequirement:
-          $ref: '#/components/schemas/InsuranceMinimumRequirement'
+          $ref: '#/components/schemas/PersonalInsuranceMinimumRequirement'
         targetAudience:
-          $ref: '#/components/schemas/EnumTargetAudience'
+          type: string
+          description: |
+            A considerar os domínios abaixo:
+
+              1. Pessoa Natural
+              2. Pessoa Jurídica
+              3. Ambas (Pessoa Natural e Jurídica)
+          maxLength: 23
+          enum:
+            - PESSOA_NATURAL
+            - PESSOA_JURIDICA
+            - PESSOA_NATURAL_JURIDICA
+          example: PESSOA_NATURAL
       additionalProperties: false
     PersonalCoverageItem:
       type: object
       required:
         - type
-        - attributes
       properties:
         type:
-          type: string
-          description: 'É o conjunto dos riscos cobertos elencados na apólice. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela Tipo de Cobertura '
-          maxLength: 62
-          enum:
-            - ADIANTAMENTO_DOENCA_ESTAGIO_TERMINAL
-            - AUXILIO_CESTA_BASICA
-            - AUXILIO_FINANCEIRO_IMEDIATO
-            - CANCELAMENTO_VIAGEM
-            - CIRURGIA
-            - COBERTURA_HERNIA
-            - COBERTURA_LER_DORT
-            - CUIDADOS_PROLONGADOS_ACIDENTE
-            - DESEMPREGO_PERDA_RENDA
-            - DESPESAS_EXTRA_INVALIDEZ_PERMANENTE_TOTAL_PARCIAL_ACIDENTE_DEI
-            - DESPESAS_EXTRA_MORTE_DEM
-            - DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS
-            - DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_BRASIL
-            - DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_EXTERIOR
-            - DIARIA_INCAPACIDADE_TOTAL_TEMPORARIA
-            - DIARIA_INTERNACAO_HOSPITALAR
-            - INTERNACAO_HOSPITALAR
-            - DIARIAS_INCAPACIDADE_PECUNIARIA_DIP
-            - DOENCA_CONGENITA_FILHOS_DCF
-            - FRATURA_OSSEA
-            - DOENCAS_TROPICAIS
-            - INCAPACIDADE_TOTAL_OU_TEMPORARIA
-            - INVALIDEZ_PERMANENTE_TOTAL_PARCIAL
-            - INVALIDEZ_TOTAL_ACIDENTE
-            - INVALIDEZ_PARCIAL_ACIDENTE
-            - INVALIDEZ_FUNCIONAL_PERMANENTE_DOENCA
-            - INVALIDEZ_LABORATIVA_DOENCA
-            - MORTE
-            - MORTE_ACIDENTAL
-            - MORTE_CONJUGE
-            - MORTE_FILHOS
-            - MORTE_ADIATAMENTO_DOENCA_ESTAGIO_TERMINAL
-            - PAGAMENTO_ANTECIPADO_ESPECIAL_DOENCA_PROFISSIONAL_PAED
-            - PERDA_AUTONOMIA_PESSOAL
-            - PERDA_INVOLUNTARIA_EMPREGO
-            - QUEIMADURA_GRAVE
-            - REGRESSO_ANTECIPADO_SANITARIO
-            - RENDA_INCAPACIDADE_TEMPORARIA
-            - RESCISAO_CONTRATUAL_CASO_MORTE_RCM
-            - RESCISAO_TRABALHISTA
-            - SERVICO_AUXILIO_FUNERAL
-            - SOBREVIVENCIA
-            - TRANSPLANTE_ORGAOS
-            - TRASLADO
-            - TRANSLADO_CORPO
-            - VERBA_RESCISORIA
-            - OUTROS
-          example: INVALIDEZ_PERMANENTE_TOTAL_PARCIAL
+          $ref: '#/components/schemas/EnumInsurancePersonalCoverageTypePersonal'
         typeAdditionalInfos:
           type: array
           description: |
@@ -1647,9 +732,17 @@ components:
     PersonalCoverageItemAttributes:
       type: object
       required:
+        - indemnityPaymentMethods
+        - indemnityPaymentFrequencies
         - minValue
         - maxValue
+        - indemnifiablePeriods
+        - maximumQtyIndemnifiableInstallments
         - gracePeriod
+        - deductibleDays
+        - deductible
+        - excludedRisks
+        - allowApartPurchase
       properties:
         indemnityPaymentMethods:
           description: Listagem da forma de pagamento da indenização para cada combinação de modalidade/cobertura do produto.
@@ -1671,18 +764,25 @@ components:
         maxValue:
           $ref: '#/components/schemas/InsurancePensionMaxValue'
         indemnifiablePeriods:
+          description: Listagem de período indenizável para cada combinação de modalidade/cobertura do produto.
           type: array
           items:
-            $ref: '#/components/schemas/EnumPersonalIndemnifiablePeriodType'
+            type: string
+            maxLength: 50
+            example: ATE_FIM_CICLO_DETERMINADO
         maximumQtyIndemnifiableInstallments:
           type: integer
           description: 'Caso o período indenizável seja relacionado a parcelas, listagem de número máximo de parcelas indenizáveis para cada combinação de modalidade/ cobertura do produto.'
           maxLength: 10
           example: 10
         gracePeriod:
-          $ref: '#/components/schemas/GracePeriod'
+          $ref: '#/components/schemas/PersonalInsuranceGracePeriod'
         differentiatedGracePeriod:
-          $ref: '#/components/schemas/GracePeriod'
+          type: string
+          description: 'Campo aberto para detalhamento de período de carência diferenciado, se houver.'
+          maxLength: 500
+          pattern: '[\w\W\s]*'
+          example: 90 DIAS
         deductibleDays:
           type: integer
           description: Listagem de franquia em dias para cada combinação de modalidade/cobertura do produto.
@@ -1829,7 +929,7 @@ components:
           type: array
           minItems: 1
           items:
-            $ref: '#/components/schemas/EnumPremiumPaymentMethodType'
+            $ref: '#/components/schemas/EnumPremiumPaymentMethodTypePersonal'
         frequencies:
           type: array
           minItems: 1
@@ -1863,6 +963,225 @@ components:
         - FRACIONADO
         - OUTRA
       example: DIARIA
+    PersonalInsuranceMinimumRequirement:
+      type: object
+      required:
+        - contractType
+        - contractingMinRequirement
+      properties:
+        contractType:
+          $ref: '#/components/schemas/EnumContractTypePersonal'
+        contractingMinRequirement:
+          type: string
+          description: Campo aberto (possibilidade de incluir URL)
+          maxLength: 1024
+          example: 'https://openinsurance.com.br/aaa'
+      additionalProperties: false
+    PersonalInsuranceGracePeriod:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Informar o prazo de carência
+          example: 90
+          maximum: 9999999999
+        unit:
+          $ref: '#/components/schemas/EnumGracePeriodUnit'
+        details:
+          type: string
+          maxLength: 500
+          pattern: '[\w\W\s]*'
+          example: Descrições adicionais do período de carência
+      additionalProperties: false
+    PersonalInsuranceReclaim:
+      type: object
+      required:
+        - gracePeriod
+      properties:
+        table:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonalInsuranceReclaimTableItem'
+          minItems: 1
+        gracePeriod:
+          $ref: '#/components/schemas/GracePeriod'
+        differenciatedPercentage:
+          description: Campo aberto (possibilidade de incluir URL)
+          example: |
+            https://openinsurance.com.br/aaa’
+            Obs.: Exceção de cobertura ou critério definido acima será descrito aqui na URL
+            Exemplo: Cobertura X: a partir de 25 meses = 100%
+          maxLength: 1024
+      additionalProperties: false
+    PersonalInsuranceReclaimTableItem:
+      type: object
+      required:
+        - initialMonthRange
+        - finalMonthRange
+        - percentage
+      properties:
+        initialMonthRange:
+          type: integer
+          maxLength: 2
+          example: 1
+        finalMonthRange:
+          type: integer
+          maxLength: 2
+          example: 12
+        percentage:
+          type: string
+          pattern: '^\d{1}\.\d{6}$'
+          maxLength: 8
+          minLength: 8
+          description: Percentual de faixa de resgate.
+          example: '0.019800'
+      additionalProperties: false
+    EnumInsurancePersonalCoverageTypePersonal:
+      type: string
+      description: 'É o conjunto dos riscos cobertos elencados na apólice. (RESOLUÇÃO CNSP Nº 341/2016). Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela Tipo de Cobertura '
+      maxLength: 62
+      enum:
+        - ADIANTAMENTO_DOENCA_ESTAGIO_TERMINAL
+        - AUXILIO_CESTA_BASICA
+        - AUXILIO_FINANCEIRO_IMEDIATO
+        - CANCELAMENTO_VIAGEM
+        - CIRURGIA
+        - COBERTURA_HERNIA
+        - COBERTURA_LER_DORT
+        - CUIDADOS_PROLONGADOS_ACIDENTE
+        - DESEMPREGO_PERDA_RENDA
+        - DESPESAS_EXTRA_INVALIDEZ_PERMANENTE_TOTAL_PARCIAL_ACIDENTE_DEI
+        - DESPESAS_EXTRA_MORTE_DEM
+        - DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS
+        - DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_BRASIL
+        - DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_EXTERIOR
+        - DIARIA_INCAPACIDADE_TOTAL_TEMPORARIA
+        - DIARIA_INTERNACAO_HOSPITALAR
+        - INTERNACAO_HOSPITALAR
+        - DIARIAS_INCAPACIDADE_PECUNIARIA_DIP
+        - DOENCA_CONGENITA_FILHOS_DCF
+        - FRATURA_OSSEA
+        - DOENCAS_TROPICAIS
+        - INCAPACIDADE_TOTAL_OU_TEMPORARIA
+        - INVALIDEZ_PERMANENTE_TOTAL_PARCIAL
+        - INVALIDEZ_TOTAL_ACIDENTE
+        - INVALIDEZ_PARCIAL_ACIDENTE
+        - INVALIDEZ_FUNCIONAL_PERMANENTE_DOENCA
+        - INVALIDEZ_LABORATIVA_DOENCA
+        - MORTE
+        - MORTE_ACIDENTAL
+        - MORTE_CONJUGE
+        - MORTE_FILHOS
+        - MORTE_ADIATAMENTO_DOENCA_ESTAGIO_TERMINAL
+        - PAGAMENTO_ANTECIPADO_ESPECIAL_DOENCA_PROFISSIONAL_PAED
+        - PERDA_AUTONOMIA_PESSOAL
+        - PERDA_INVOLUNTARIA_EMPREGO
+        - QUEIMADURA_GRAVE
+        - REGRESSO_ANTECIPADO_SANITARIO
+        - RENDA_INCAPACIDADE_TEMPORARIA
+        - RESCISAO_CONTRATUAL_CASO_MORTE_RCM
+        - RESCISAO_TRABALHISTA
+        - SERVICO_AUXILIO_FUNERAL
+        - SOBREVIVENCIA
+        - TRANSPLANTE_ORGAOS
+        - TRASLADO
+        - TRANSLADO_CORPO
+        - VERBA_RESCISORIA
+        - DOENCA_GRAVE
+        - TRANSLADO_MEDICO
+        - OUTROS
+      example: INVALIDEZ_PERMANENTE_TOTAL_PARCIAL
+    EnumPremiumPaymentMethodTypePersonal:
+      type: string
+      description: |
+        Meio de pagamento escolhido pelo segurado. A considerar os domínios abaixo:
+          1. Cartão de Crédito
+          2. Cartão de Débito
+          3. Débito em conta corrente
+          4. Débito em conta poupança
+          5. Boleto bancário
+          6. PIX
+          7. Consignação em Folha de Pagamento
+          8. Pontos de Programa de Benefício
+          9. Regra de Parceiro
+      maxLength: 27
+      enum:
+        - CARTAO_CREDITO
+        - CARTAO_DEBITO
+        - DEBITO_CONTA_CORRENTE
+        - DEBITO_CONTA_POUPANCA
+        - BOLETO_BANCARIO
+        - PIX
+        - CONSIGNACAO_FOLHA_PAGAMENTO
+        - PONTOS_PROGRAMA_BENEFICIO
+        - REGRA_PARCEIRO
+      example: CARTAO_CREDITO
+    EnumContractTypePersonal:
+      type: string
+      description: |
+        A considerar os domínios abaixo:
+          1. Coletivo;
+          2. Individual
+      maxLength: 10
+      enum:
+        - COLETIVO
+        - INDIVIDUAL
+      example: COLETIVO
+    PersonalInsuranceSociety:
+      type: object
+      description: Conjunto de informações relativas à seguradora do produto de open insurance
+      required:
+        - name
+        - cnpjNumber
+        - brand
+      properties:
+        name:
+          type: string
+          description: Nome da Sociedade Seguradora.
+          maxLength: 80
+          example: Society A1
+        cnpjNumber:
+          $ref: '#/components/schemas/CnpjNumber'
+        brand:
+          type: string
+          description: 'Nome da marca reportada pela sociedade seguradora participante do Open Finance. O conceito a que se refere a marca é em essência uma promessa das sociedades sob ela em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.'
+          maxLength: 80
+          example: Marca
+      additionalProperties: false
+    PersonalInsurancePortabilityGraceTime:
+      type: object
+      required:
+        - amount
+        - unit
+      properties:
+        amount:
+          type: integer
+          format: int64
+          description: Informar o prazo de carência
+          example: 90
+          maximum: 9999999999
+        unit:
+          $ref: '#/components/schemas/EnumGracePeriodUnit'
+      additionalProperties: false
+    BenefitRecalculation:
+      type: object
+      required:
+        - criterias
+      properties:
+        criterias:
+          type: array
+          items:
+            type: string
+            enum:
+              - INDICE
+              - VINCULADO_SALDO_DEVEDOR
+              - VARIAVEL_ACORDO_CRITERIO_ESPECIFICO
+        updateIndexes:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnumInsurancePersonalBenefitRecalculationUpdateIndex'
+      additionalProperties: false
     Links:
       type: object
       description: Referências para outros recusos da API requisitada.
@@ -1930,23 +1249,40 @@ components:
           format: date-time
           example: '2021-05-21T08:30:00Z'
       additionalProperties: false
-    Phase4Meta:
+    ResponseError:
       type: object
-      description: Meta informações referente à API requisitada.
       required:
-        - totalRecords
-        - totalPages
+        - errors
       properties:
-        totalRecords:
-          type: integer
-          format: int32
-          description: Número total de registros no resultado
-          example: 1
-        totalPages:
-          type: integer
-          format: int32
-          description: Número total de páginas no resultado
-          example: 1
+        errors:
+          type: array
+          minItems: 1
+          maxItems: 13
+          items:
+            type: object
+            required:
+              - code
+              - title
+              - detail
+            properties:
+              code:
+                description: Código de erro específico do endpoint
+                type: string
+                pattern: '[\w\W\s]*'
+                maxLength: 255
+              title:
+                description: Título legível por humanos deste erro específico
+                type: string
+                pattern: '[\w\W\s]*'
+                maxLength: 255
+              detail:
+                description: Descrição legível por humanos deste erro específico
+                type: string
+                pattern: '[\w\W\s]*'
+                maxLength: 2048
+            additionalProperties: false
+        meta:
+          $ref: '#/components/schemas/Meta'
       additionalProperties: false
   parameters:
     page:
@@ -1970,18 +1306,6 @@ components:
         format: int32
         maximum: 1000
   responses:
-    OKResponseAutomotiveInsuranceList:
-      description: Dados de seguro(s) automotivos obtidos com sucesso.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/OKResponseAutomotiveInsuranceList'
-    OKResponseHomeInsuranceList:
-      description: Dados de seguro(s) residenciais obtidos com sucesso.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/OKResponseHomeInsuranceList'
     OKResponsePersonalInsuranceList:
       description: Dados de seguro(s) pessoais obtidos com sucesso.
       content:
@@ -1993,21 +1317,33 @@ components:
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/responses/NotFound/content/application~1json%3B%20charset%3Dutf-8/schema'
+            $ref: '#/components/schemas/ResponseError'
     InternalServerError:
       description: Ocorreu um erro no gateway da API ou no microsserviço
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/responses/NotFound/content/application~1json%3B%20charset%3Dutf-8/schema'
+            $ref: '#/components/schemas/ResponseError'
     MethodNotAllowed:
       description: O consumidor tentou acessar o recurso com um método não suportado
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/responses/NotFound/content/application~1json%3B%20charset%3Dutf-8/schema'
+            $ref: '#/components/schemas/ResponseError'
     NotFound:
       description: O recurso solicitado não existe ou não foi implementado
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: '#/components/schemas/ResponseError'
+    TooManyRequests:
+      description: 'A operação foi recusada, pois muitas solicitações foram feitas dentro de um determinado período ou o limite de requisições concorrentes foi atingido.'
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: '#/components/schemas/ResponseError'
+    SiteIsOverloaded:
+      description: 'O site está sobrecarregado e a operação foi recusada, pois foi atingido o limite máximo de TPS global, neste momento.'
       content:
         application/json; charset=utf-8:
           schema:
@@ -2041,13 +1377,15 @@ components:
                       type: string
                       pattern: '[\w\W\s]*'
                       maxLength: 2048
-                  additionalProperties: false
               meta:
-                $ref: '#/components/schemas/Meta'
-            additionalProperties: false
-    TooManyRequests:
-      description: 'A operação foi recusada, pois muitas solicitações foram feitas dentro de um determinado período ou o limite global de requisições concorrentes foi atingido'
-      content:
-        application/json; charset=utf-8:
-          schema:
-            $ref: '#/components/responses/NotFound/content/application~1json%3B%20charset%3Dutf-8/schema'
+                type: object
+                description: Meta informações referente à API requisitada.
+                required:
+                  - requestDateTime
+                properties:
+                  requestDateTime:
+                    description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
+                    type: string
+                    maxLength: 20
+                    format: date-time
+                    example: '2021-05-21T08:30:00Z'

--- a/swagger-apis/insurances/index.html
+++ b/swagger-apis/insurances/index.html
@@ -45,8 +45,9 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        urls: [	{"name": "1.0.0-rc1.0", "url": "./1.0.0-rc1.0.yml"}],
-        "urls.primaryName": "1.0.0-rc1.0",  // default spec
+        urls: [	{"name": "1.0.0-rc1.0", "url": "./1.0.0-rc1.0.yml"},
+								{"name": "1.0.0-rc2.0", "url": "./1.0.0-rc2.0.yml"}],
+        "urls.primaryName": "1.0.0-rc2.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
         supportedSubmitMethods:[],


### PR DESCRIPTION
#### Feat(Insurances)
- PC67: Tornar campos obrigatórios;
- PC68: Alterar Enums;
- PC69: Criar campo brand.name;
- PC70: Alterar a mandatoriedade;
- PC 71: Criar os campos;
- PC 72: data/coverages/attributes/gracePeriod/details, data/portabilityGraceTime/details;
- PC 73: Altera o objeto differentiatedGracePeriod;