### PR TITLE
GT Servico - Feat - Habilitando propriedade showExtension no swagger

### DIFF
--- a/swagger-apis/enrollments/index.html
+++ b/swagger-apis/enrollments/index.html
@@ -55,6 +55,7 @@
         dom_id: '#swagger-ui',
         deepLinking: true,
         supportedSubmitMethods:[],
+        showExtensions:true,
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset 

--- a/swagger-apis/payments/index.html
+++ b/swagger-apis/payments/index.html
@@ -77,6 +77,7 @@
         dom_id: '#swagger-ui',
         deepLinking: true,
         supportedSubmitMethods:[],
+        showExtensions:true,
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset 

--- a/swagger-apis/webhook/index.html
+++ b/swagger-apis/webhook/index.html
@@ -59,6 +59,7 @@
         dom_id: '#swagger-ui',
         deepLinking: true,
         supportedSubmitMethods:[],
+        showExtensions:true,
         presets: [
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset 


### PR DESCRIPTION
Ajustando arquivos index.html das apis, possibilitando a visualização de tags customizadas iniciando com **x-**, através da parametrização _**showExtensions: true**_ , fornecida pelo componente do swagger.

Segue link para mais informações sobre o componente e sua utilização: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
