### PR TITLE
GT Dados Abertos - Feat - Habilitando propriedade showExtension no swagger

### DIFF
--- a/swagger-apis/acquiring-services/index.html
+++ b/swagger-apis/acquiring-services/index.html
@@ -51,6 +51,7 @@
         "urls.primaryName": "1.0.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/admin/index.html
+++ b/swagger-apis/admin/index.html
@@ -59,6 +59,7 @@
         "urls.primaryName": "2.0.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/capitalization-bonds/index.html
+++ b/swagger-apis/capitalization-bonds/index.html
@@ -53,6 +53,7 @@
         "urls.primaryName": "1.0.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/channels/index.html
+++ b/swagger-apis/channels/index.html
@@ -56,6 +56,7 @@
         "urls.primaryName": "2.0.0-beta.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/common/index.html
+++ b/swagger-apis/common/index.html
@@ -56,6 +56,7 @@
         "urls.primaryName": "2.0.0-beta.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/exchange/index.html
+++ b/swagger-apis/exchange/index.html
@@ -51,6 +51,7 @@
         "urls.primaryName": "1.0.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/insurances/index.html
+++ b/swagger-apis/insurances/index.html
@@ -53,6 +53,7 @@
         "urls.primaryName": "1.0.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/investments/index.html
+++ b/swagger-apis/investments/index.html
@@ -51,6 +51,7 @@
         "urls.primaryName": "1.0.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/opendata-accounts/index.html
+++ b/swagger-apis/opendata-accounts/index.html
@@ -50,6 +50,7 @@
         "urls.primaryName": "1.0.0-beta.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/opendata-creditcards/index.html
+++ b/swagger-apis/opendata-creditcards/index.html
@@ -50,6 +50,7 @@
         "urls.primaryName": "1.0.0-beta.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/opendata-financings/index.html
+++ b/swagger-apis/opendata-financings/index.html
@@ -50,6 +50,7 @@
         "urls.primaryName": "1.0.0-beta.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/opendata-invoicefinancings/index.html
+++ b/swagger-apis/opendata-invoicefinancings/index.html
@@ -50,6 +50,7 @@
         "urls.primaryName": "1.0.0-beta.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/opendata-loans/index.html
+++ b/swagger-apis/opendata-loans/index.html
@@ -50,6 +50,7 @@
         "urls.primaryName": "1.0.0-beta.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/opendata-unarranged/index.html
+++ b/swagger-apis/opendata-unarranged/index.html
@@ -50,6 +50,7 @@
         "urls.primaryName": "1.0.0-beta.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/pension/index.html
+++ b/swagger-apis/pension/index.html
@@ -53,6 +53,7 @@
         "urls.primaryName": "1.0.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/products-services/index.html
+++ b/swagger-apis/products-services/index.html
@@ -54,6 +54,7 @@
         "urls.primaryName": "1.0.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
Ajustando arquivos index.html das apis, possibilitando a visualização de tags customizadas iniciando com **x-**, através da parametrização _**showExtensions: true**_ , fornecida pelo componente do swagger.

Segue link para mais informações sobre o componente e sua utilização: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
