### PR TITLE
GT Dados do Cliente  - Feat - Habilitando propriedade showExtension no swagger

### DIFF
--- a/swagger-apis/accounts/index.html
+++ b/swagger-apis/accounts/index.html
@@ -63,6 +63,7 @@
         "urls.primaryName": "2.1.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/bank-fixed-incomes/index.html
+++ b/swagger-apis/bank-fixed-incomes/index.html
@@ -54,6 +54,7 @@
         "urls.primaryName": "1.0.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/consents/index.html
+++ b/swagger-apis/consents/index.html
@@ -66,6 +66,7 @@
         "urls.primaryName": "2.2.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/credit-cards/index.html
+++ b/swagger-apis/credit-cards/index.html
@@ -63,6 +63,7 @@
         "urls.primaryName": "3.0.0-beta.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/credit-fixed-incomes/index.html
+++ b/swagger-apis/credit-fixed-incomes/index.html
@@ -53,6 +53,7 @@
         "urls.primaryName": "1.0.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/customers/index.html
+++ b/swagger-apis/customers/index.html
@@ -58,6 +58,7 @@
         "urls.primaryName": "2.0.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/exchanges/index.html
+++ b/swagger-apis/exchanges/index.html
@@ -52,6 +52,7 @@
         "urls.primaryName": "1.0.0-rc.3",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/financings/index.html
+++ b/swagger-apis/financings/index.html
@@ -61,6 +61,7 @@
         "urls.primaryName": "2.1.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/funds/index.html
+++ b/swagger-apis/funds/index.html
@@ -54,6 +54,7 @@
         "urls.primaryName": "1.0.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/invoice-financings/index.html
+++ b/swagger-apis/invoice-financings/index.html
@@ -61,6 +61,7 @@
         "urls.primaryName": "2.1.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/loans/index.html
+++ b/swagger-apis/loans/index.html
@@ -61,6 +61,7 @@
         "urls.primaryName": "2.1.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/resources/index.html
+++ b/swagger-apis/resources/index.html
@@ -60,6 +60,7 @@
         "urls.primaryName": "3.0.0-beta.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/treasure-titles/index.html
+++ b/swagger-apis/treasure-titles/index.html
@@ -53,6 +53,7 @@
         "urls.primaryName": "1.0.1",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/unarranged-accounts-overdraft/index.html
+++ b/swagger-apis/unarranged-accounts-overdraft/index.html
@@ -61,6 +61,7 @@
         "urls.primaryName": "2.1.0",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,

--- a/swagger-apis/variable-incomes/index.html
+++ b/swagger-apis/variable-incomes/index.html
@@ -54,6 +54,7 @@
         "urls.primaryName": "1.0.2",  // default spec
         dom_id: '#swagger-ui',
         deepLinking: true,
+        showExtensions:true,
         supportedSubmitMethods:[],
         presets: [
           SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
Ajustando arquivos index.html das apis, possibilitando a visualização de tags customizadas iniciando com **x-**, através da parametrização _**showExtensions: true**_ , fornecida pelo componente do swagger.

Segue link para mais informações sobre o componente e sua utilização: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
